### PR TITLE
feat: add version badge in upper-right corner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Build
         working-directory: src/arrange-v4
-        run: npm run build
+        run: |
+          export NEXT_PUBLIC_APP_VERSION="$(date -u +'%Y%m%d%H%M')-$(echo '${{ github.sha }}' | cut -c1-6)"
+          npm run build
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/src/arrange-v4/app/layout.tsx
+++ b/src/arrange-v4/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/AuthProvider";
+import VersionBadge from "@/components/VersionBadge";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AuthProvider>
+          <VersionBadge />
           {children}
         </AuthProvider>
       </body>

--- a/src/arrange-v4/components/VersionBadge.tsx
+++ b/src/arrange-v4/components/VersionBadge.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+const version = process.env.NEXT_PUBLIC_APP_VERSION || "local";
+
+export default function VersionBadge() {
+  return (
+    <span
+      style={{
+        position: "fixed",
+        top: 8,
+        right: 12,
+        fontSize: "0.7rem",
+        color: "#888",
+        zIndex: 9999,
+        pointerEvents: "none",
+        userSelect: "none",
+      }}
+    >
+      {version}
+    </span>
+  );
+}

--- a/src/arrange-v4/next.config.ts
+++ b/src/arrange-v4/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+const appVersion = process.env.NEXT_PUBLIC_APP_VERSION || "local";
 
 const nextConfig: NextConfig = {
   output: "export",
@@ -10,6 +11,7 @@ const nextConfig: NextConfig = {
   },
   env: {
     NEXT_PUBLIC_BASE_PATH: basePath,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
   },
 };
 


### PR DESCRIPTION
Display build version (yyyyMMddHHmm-commit) in the top-right corner. Shows 'local' in development; GitHub 
  Actions sets the timestamp and first 6 chars of the commit SHA at build time.