### PR TITLE
Default cancelled items to hide in matrix view

### DIFF
--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -23,7 +23,7 @@ const DEFAULT_STATUS_FILTERS: Record<TodoStatus, StatusFilterMode> = {
   inProgress: 'showAll',
   blocked: 'showAll',
   finished: 'todayOnly',
-  cancelled: 'todayOnly',
+  cancelled: 'hide',
 };
 
 const FILTER_MODES: StatusFilterMode[] = ['showAll', 'todayOnly', 'hide'];


### PR DESCRIPTION
Changed the default status filter for 'cancelled' items from 'todayOnly' to 'hide' so they are hidden by 
  default in the matrix view. Users can still toggle them visible via the filter bar.
   
   Fixes #20