### PR TITLE
Fix sweep reliability and storage checks

### DIFF
--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -300,27 +300,33 @@ function MatrixPageContent() {
 
       // Sweep stale items across ALL calendars once per session (non-blocking)
       if (!hasSessionSweepRun()) {
-        markSessionSweepDone();
         const sweepAccessToken = response.accessToken;
         const sweepBookId = bookId;
+        // Reuse already-fetched calendars from component state if available
+        const sweepCalendars = calendars.length > 0
+          ? calendars
+          : filterArrangeCalendars(await getCalendars(sweepAccessToken));
         void (async () => {
           try {
-            const allCalendars = await getCalendars(sweepAccessToken);
-            const arrangeCalendars = filterArrangeCalendars(allCalendars);
-
-            for (const cal of arrangeCalendars) {
-              if (!cal.id) continue;
-              try {
-                const calEvents = await getCalendarEvents(
-                  sweepAccessToken, cal.id,
-                  startDate.toISOString(), endDate.toISOString()
-                );
-                const calTodos = calEvents.map(event => parseTodoData(event));
-                await sweepStaleTodos(sweepAccessToken, cal.id, calTodos);
-              } catch (calError) {
-                console.error(`Error sweeping calendar ${cal.id}:`, calError);
+            const calendarQueue = sweepCalendars.filter(c => c.id);
+            const CONCURRENCY = 5;
+            let i = 0;
+            const processNext = async () => {
+              while (i < calendarQueue.length) {
+                const cal = calendarQueue[i++];
+                try {
+                  const calEvents = await getCalendarEvents(
+                    sweepAccessToken, cal.id!,
+                    startDate.toISOString(), endDate.toISOString()
+                  );
+                  const calTodos = calEvents.map(event => parseTodoData(event));
+                  await sweepStaleTodos(sweepAccessToken, cal.id!, calTodos);
+                } catch (calError) {
+                  console.error(`Error sweeping calendar ${cal.id}:`, calError);
+                }
               }
-            }
+            };
+            await Promise.all(Array.from({ length: CONCURRENCY }, () => processNext()));
 
             // Refresh current view if still on the same book
             if (bookIdRef.current === sweepBookId) {
@@ -332,6 +338,8 @@ function MatrixPageContent() {
                 setTodoItems(refreshedEvents.map(event => parseTodoData(event)));
               }
             }
+
+            markSessionSweepDone();
           } catch (sweepError) {
             console.error('Error during session sweep:', sweepError);
           }

--- a/src/arrange-v4/lib/bookStorage.ts
+++ b/src/arrange-v4/lib/bookStorage.ts
@@ -1,7 +1,7 @@
 const LAST_BOOK_ID_KEY = 'arrange_lastBookId';
 const SESSION_SWEEP_KEY = 'arrange_sweepDone';
 
-function isStorageAvailable(): boolean {
+function isLocalStorageAvailable(): boolean {
   try {
     return typeof window !== 'undefined' && !!window.localStorage;
   } catch {
@@ -9,8 +9,16 @@ function isStorageAvailable(): boolean {
   }
 }
 
+function isSessionStorageAvailable(): boolean {
+  try {
+    return typeof window !== 'undefined' && !!window.sessionStorage;
+  } catch {
+    return false;
+  }
+}
+
 export function getLastBookId(): string | null {
-  if (!isStorageAvailable()) return null;
+  if (!isLocalStorageAvailable()) return null;
   try {
     return localStorage.getItem(LAST_BOOK_ID_KEY);
   } catch {
@@ -19,7 +27,7 @@ export function getLastBookId(): string | null {
 }
 
 export function setLastBookId(bookId: string): void {
-  if (!isStorageAvailable()) return;
+  if (!isLocalStorageAvailable()) return;
   try {
     localStorage.setItem(LAST_BOOK_ID_KEY, bookId);
   } catch {
@@ -28,7 +36,7 @@ export function setLastBookId(bookId: string): void {
 }
 
 export function clearLastBookId(): void {
-  if (!isStorageAvailable()) return;
+  if (!isLocalStorageAvailable()) return;
   try {
     localStorage.removeItem(LAST_BOOK_ID_KEY);
   } catch {
@@ -37,16 +45,16 @@ export function clearLastBookId(): void {
 }
 
 export function hasSessionSweepRun(): boolean {
-  if (!isStorageAvailable()) return true;
+  if (!isSessionStorageAvailable()) return false;
   try {
     return sessionStorage.getItem(SESSION_SWEEP_KEY) === 'true';
   } catch {
-    return true;
+    return false;
   }
 }
 
 export function markSessionSweepDone(): void {
-  if (!isStorageAvailable()) return;
+  if (!isSessionStorageAvailable()) return;
   try {
     sessionStorage.setItem(SESSION_SWEEP_KEY, 'true');
   } catch {


### PR DESCRIPTION
Addresses PR #28 review comments:
   
   1. **Reuse calendars state** — avoid redundant `getCalendars()` Graph API call
   2. **Parallel calendar sweep** — concurrency pool of 5 (was sequential)
   3. **Separate storage checks** — `isSessionStorageAvailable()` for sweep helpers, `isLocalStorageAvailable()` for bookId
   4. **Return false on storage error** — sweep runs even in privacy mode
   5. **Mark sweep done after success** — allows retry on failure