### PR TITLE
feat: support tags (categories) — add, edit, filter, manage (#21)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,77 @@
+# Copilot Instructions — Arrange V4
+
+## Build & Run
+
+```bash
+cd src/arrange-v4
+npm ci          # install (use ci, not install, for reproducible builds)
+npm run dev     # dev server at http://localhost:3000
+npm run build   # static export to src/arrange-v4/out
+npm run lint    # ESLint (Next.js Core Web Vitals + TypeScript presets)
+```
+
+There is no test framework configured — no test runner or test scripts exist.
+
+## Architecture
+
+Arrange is a **fully client-side** Next.js 16 app (App Router, `output: "export"`) with **no backend**. The browser authenticates via MSAL and talks directly to the Microsoft Graph API. There is no middleware, no API routes, and no server-side data store.
+
+### Data model: Calendar-as-database
+
+- **Books** = Outlook calendars whose names end with `" by arrange"`.
+- **TODO items** = calendar events in those calendars.
+  - `subject` → task title.
+  - `start`/`end` → estimated start (ETS) and estimated time of accomplishment (ETA).
+  - `categories` → tags.
+  - `body.content` → HTML containing a `<pre>` block with structured JSON between `====ArrangeDataStart====` / `====ArrangeDataEnd====` markers. This JSON holds `status`, `urgent`, `important`, `checklist`, `remarks`, timestamps, and original pre-bump dates.
+
+### Date-bump behavior
+
+Non-terminal items (`new`, `inProgress`, `blocked`) are fetched via a ±30-day calendar view window. To prevent items from falling out of range, stale dates are bumped forward to today (preserving time-of-day and duration). Original dates are saved to `originalEtsDateTime`/`originalEtaDateTime` on first bump and never overwritten. Terminal items (`finished`, `cancelled`) are never bumped.
+
+### Authentication
+
+MSAL authenticates against the `consumers` authority (personal Microsoft accounts). The redirect URI is `window.location.origin + NEXT_PUBLIC_BASE_PATH`. Tokens are cached in `sessionStorage`. Token acquisition uses `acquireTokenSilent()` with a popup fallback.
+
+### State management
+
+All state is React hooks (`useState`, `useMemo`) — no global state library. Persistent client-side state (last selected book, sweep tracking) uses `localStorage`/`sessionStorage` via `bookStorage.ts`.
+
+### Optimistic UI
+
+User actions immediately update local state, then sync to Graph in the background. On failure, state rolls back to a snapshot captured before the optimistic update. This pattern is used for drag-and-drop quadrant changes, status updates, field edits, and checklist toggles.
+
+## Key Services (src/arrange-v4/lib/)
+
+| File | Responsibility |
+|---|---|
+| `graphService.ts` | Graph API CRUD for calendars and events, with `@odata.nextLink` pagination |
+| `todoDataService.ts` | Domain logic: create/update/parse TODO items, serialize to/from marker-delimited JSON, sweep stale items |
+| `msalConfig.ts` | MSAL instance configuration and Graph API scopes (`User.Read`, `Calendars.ReadWrite`) |
+| `bookStorage.ts` | `localStorage`/`sessionStorage` helpers for last-book-id and sweep state |
+| `calendarUtils.ts` | Filtering calendars by the `" by arrange"` suffix and extracting display names |
+
+## Conventions
+
+- **TypeScript strict mode** with `isolatedModules`. Nullability must be modeled explicitly (e.g., `useRef<T | null>(null)`).
+- **Path alias**: `@/*` maps to the project root — use `@/lib/graphService` style imports.
+- **CSS Modules**: Every component has a colocated `.module.css` file. No global CSS beyond `globals.css`.
+- **Component files**: PascalCase (`AddTodoItem.tsx`). No barrel/index exports.
+- **Client components**: Pages and components use `'use client'` since there is no server runtime.
+- **basePath**: Configurable via `NEXT_PUBLIC_BASE_PATH` env var. Use Next.js `Link`/`useRouter` for navigation (never raw `<a href="/">`) to respect the base path.
+- **Version badge**: `NEXT_PUBLIC_APP_VERSION` defaults to `"local"` in dev; CI sets it to `YYYYMMDDHHmm-<short SHA>`.
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `NEXT_PUBLIC_AZURE_CLIENT_ID` | Azure AD app registration client ID | Built-in dev ID |
+| `NEXT_PUBLIC_BASE_PATH` | Base path for hosted deployments | `""` |
+| `NEXT_PUBLIC_APP_VERSION` | Version shown in UI | `"local"` |
+
+## CI/CD
+
+The GitHub Actions workflow (`.github/workflows/deploy.yml`) triggers on push to `main`:
+
+1. `npm ci` → `npm run build` (with version stamp) → uploads `src/arrange-v4/out` artifact.
+2. Deploys static files to GitHub Pages.

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -275,14 +275,23 @@
   background-color: #1d4ed8;
 }
 
-.categoryFilterSection {
+.tagBar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 6px;
-  width: 100%;
-  padding-top: 8px;
-  border-top: 1px solid #e5e7eb;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.tagBarLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #374151;
+  margin-right: 2px;
 }
 
 .categoryFilterChips {

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -275,6 +275,60 @@
   background-color: #1d4ed8;
 }
 
+.categoryFilterSection {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding-top: 8px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.categoryFilterChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.categoryFilterChip {
+  font-size: 0.7rem;
+  padding: 3px 10px;
+  border-radius: 16px;
+  border: 1px solid #d1d5db;
+  background-color: transparent;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-weight: 500;
+}
+
+.categoryFilterChip:hover {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.categoryFilterChipActive {
+  background-color: #dbeafe;
+  border-color: #2563eb;
+  color: #1e40af;
+  font-weight: 600;
+}
+
+.categoryFilterChipActive:hover {
+  background-color: #bfdbfe;
+}
+
+.categoryFilterClear {
+  border-color: #fca5a5;
+  color: #dc2626;
+}
+
+.categoryFilterClear:hover {
+  background-color: #fef2f2;
+  border-color: #dc2626;
+}
+
 .matrix {
   display: grid;
   grid-template-columns: 1fr;

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -287,11 +287,21 @@
   border-radius: 8px;
 }
 
-.tagBarLabel {
+.tagBarToggle {
   font-size: 0.75rem;
   font-weight: 600;
   color: #374151;
-  margin-right: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  white-space: nowrap;
+  transition: background-color 0.15s;
+}
+
+.tagBarToggle:hover {
+  background-color: #e5e7eb;
 }
 
 .categoryFilterChips {

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -196,10 +196,16 @@
 
 .matrixHeader {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   gap: 12px;
   margin-bottom: 12px;
+}
+
+.matrixHeaderActions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .matrixHeader .sectionTitle {
@@ -285,23 +291,6 @@
   background-color: #f9fafb;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
-}
-
-.tagBarToggle {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #374151;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
-  white-space: nowrap;
-  transition: background-color 0.15s;
-}
-
-.tagBarToggle:hover {
-  background-color: #e5e7eb;
 }
 
 .categoryFilterChips {

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -550,26 +550,25 @@ function MatrixPageContent() {
     }
   };
 
-  const handleDeleteTag = async (tag: string) => {
-    if (!bookId) return;
-
-    const affectedItems = todoItems.filter(item => item.categories?.includes(tag));
-    if (affectedItems.length === 0) return;
+  const bulkUpdateCategories = async (
+    affectedItems: (TodoItem & { id?: string })[],
+    computeNewCategories: (item: TodoItem & { id?: string }) => string[],
+    updateFilterState: () => void,
+  ) => {
+    if (!bookId || affectedItems.length === 0) return;
 
     const previousItems = [...todoItems];
+    const previousSelectedCategories = new Set(selectedCategories);
+    const previousShowUncategorized = showUncategorized;
+
     setTodoItems(items =>
       items.map(item =>
-        item.categories?.includes(tag)
-          ? { ...item, categories: item.categories.filter(c => c !== tag) }
+        affectedItems.some(a => a.id === item.id)
+          ? { ...item, categories: computeNewCategories(item) }
           : item
       )
     );
-    // Clean up filter state
-    setSelectedCategories(prev => {
-      const next = new Set(prev);
-      next.delete(tag);
-      return next;
-    });
+    updateFilterState();
 
     try {
       const account = accounts[0];
@@ -581,108 +580,55 @@ function MatrixPageContent() {
           const item = affectedItems[idx++];
           if (!item.id) continue;
           await updateTodoItem(response.accessToken, bookId, item.id, {
-            categories: (item.categories || []).filter(c => c !== tag),
+            categories: computeNewCategories(item),
           });
         }
       };
       await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
     } catch (error: any) {
-      console.error('Error deleting tag:', error);
+      console.error('Error updating tags:', error);
       setTodoItems(previousItems);
+      setSelectedCategories(previousSelectedCategories);
+      setShowUncategorized(previousShowUncategorized);
       throw error;
     }
+  };
+
+  const handleDeleteTag = async (tag: string) => {
+    const affected = todoItems.filter(item => item.categories?.includes(tag));
+    await bulkUpdateCategories(
+      affected,
+      (item) => (item.categories || []).filter(c => c !== tag),
+      () => setSelectedCategories(prev => { const next = new Set(prev); next.delete(tag); return next; }),
+    );
   };
 
   const handleRenameTag = async (oldTag: string, newTag: string) => {
-    if (!bookId) return;
-
-    const affectedItems = todoItems.filter(item => item.categories?.includes(oldTag));
-    if (affectedItems.length === 0) return;
-
-    const previousItems = [...todoItems];
-    setTodoItems(items =>
-      items.map(item =>
-        item.categories?.includes(oldTag)
-          ? { ...item, categories: item.categories.map(c => c === oldTag ? newTag : c) }
-          : item
-      )
+    const affected = todoItems.filter(item => item.categories?.includes(oldTag));
+    await bulkUpdateCategories(
+      affected,
+      (item) => (item.categories || []).map(c => c === oldTag ? newTag : c),
+      () => setSelectedCategories(prev => {
+        if (!prev.has(oldTag)) return prev;
+        const next = new Set(prev); next.delete(oldTag); next.add(newTag); return next;
+      }),
     );
-    // Update filter state
-    setSelectedCategories(prev => {
-      if (!prev.has(oldTag)) return prev;
-      const next = new Set(prev);
-      next.delete(oldTag);
-      next.add(newTag);
-      return next;
-    });
-
-    try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
-      const CONCURRENCY = 5;
-      let idx = 0;
-      const worker = async () => {
-        while (idx < affectedItems.length) {
-          const item = affectedItems[idx++];
-          if (!item.id) continue;
-          await updateTodoItem(response.accessToken, bookId, item.id, {
-            categories: (item.categories || []).map(c => c === oldTag ? newTag : c),
-          });
-        }
-      };
-      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
-    } catch (error: any) {
-      console.error('Error renaming tag:', error);
-      setTodoItems(previousItems);
-      throw error;
-    }
   };
 
   const handleMergeTag = async (sourceTag: string, targetTag: string) => {
-    if (!bookId) return;
-
-    const affectedItems = todoItems.filter(item => item.categories?.includes(sourceTag));
-    if (affectedItems.length === 0) return;
-
-    const previousItems = [...todoItems];
-    setTodoItems(items =>
-      items.map(item => {
-        if (!item.categories?.includes(sourceTag)) return item;
-        const withoutSource = item.categories.filter(c => c !== sourceTag);
-        const merged = withoutSource.includes(targetTag) ? withoutSource : [...withoutSource, targetTag];
-        return { ...item, categories: merged };
-      })
+    const affected = todoItems.filter(item => item.categories?.includes(sourceTag));
+    await bulkUpdateCategories(
+      affected,
+      (item) => {
+        const cats = item.categories || [];
+        const without = cats.filter(c => c !== sourceTag);
+        return without.includes(targetTag) ? without : [...without, targetTag];
+      },
+      () => setSelectedCategories(prev => {
+        if (!prev.has(sourceTag)) return prev;
+        const next = new Set(prev); next.delete(sourceTag); next.add(targetTag); return next;
+      }),
     );
-    // Update filter state: remove source, keep target
-    setSelectedCategories(prev => {
-      if (!prev.has(sourceTag)) return prev;
-      const next = new Set(prev);
-      next.delete(sourceTag);
-      next.add(targetTag);
-      return next;
-    });
-
-    try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
-      const CONCURRENCY = 5;
-      let idx = 0;
-      const worker = async () => {
-        while (idx < affectedItems.length) {
-          const item = affectedItems[idx++];
-          if (!item.id) continue;
-          const cats = item.categories || [];
-          const withoutSource = cats.filter(c => c !== sourceTag);
-          const merged = withoutSource.includes(targetTag) ? withoutSource : [...withoutSource, targetTag];
-          await updateTodoItem(response.accessToken, bookId, item.id, { categories: merged });
-        }
-      };
-      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
-    } catch (error: any) {
-      console.error('Error merging tags:', error);
-      setTodoItems(previousItems);
-      throw error;
-    }
   };
 
   const handleLogin = async () => {

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -639,12 +639,22 @@ function MatrixPageContent() {
             <div className={styles.matrixSection}>
               <div className={styles.matrixHeader}>
                 <span className={styles.filterCount}>Showing {filteredTodoItems.length} of {todoItems.length} items</span>
-                <button
-                  className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
-                  onClick={() => setShowFilters(prev => !prev)}
-                >
-                  {showFilters ? '▲ Status' : '▼ Status'}
-                </button>
+                <div className={styles.matrixHeaderActions}>
+                  {allCategories.length > 0 && (
+                    <button
+                      className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                      onClick={() => setShowTags(prev => !prev)}
+                    >
+                      {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
+                    </button>
+                  )}
+                  <button
+                    className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                    onClick={() => setShowFilters(prev => !prev)}
+                  >
+                    {showFilters ? '▲ Status' : '▼ Status'}
+                  </button>
+                </div>
               </div>
               {showFilters && (
                 <div className={styles.filterBar}>
@@ -666,16 +676,9 @@ function MatrixPageContent() {
                   ))}
                 </div>
               )}
-              {allCategories.length > 0 && (
+              {showTags && allCategories.length > 0 && (
                 <div className={styles.tagBar}>
-                  <button
-                    className={styles.tagBarToggle}
-                    onClick={() => setShowTags(prev => !prev)}
-                  >
-                    {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
-                  </button>
-                  {showTags && (
-                    <div className={styles.categoryFilterChips}>
+                  <div className={styles.categoryFilterChips}>
                       <button
                         className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
                         onClick={() => setShowUncategorized(prev => !prev)}
@@ -707,7 +710,6 @@ function MatrixPageContent() {
                         </button>
                       )}
                     </div>
-                  )}
                 </div>
               )}
               <div className={styles.matrix}>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -642,7 +642,7 @@ function MatrixPageContent() {
                   className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
                   onClick={() => setShowFilters(prev => !prev)}
                 >
-                  {showFilters ? '▲ Filters' : '▼ Filters'}
+                  {showFilters ? '▲ Status' : '▼ Status'}
                 </button>
               </div>
               {showFilters && (
@@ -663,43 +663,43 @@ function MatrixPageContent() {
                       </div>
                     </div>
                   ))}
-                  {allCategories.length > 0 && (
-                    <div className={styles.categoryFilterSection}>
-                      <span className={styles.filterLabel}>Tags</span>
-                      <div className={styles.categoryFilterChips}>
+                </div>
+              )}
+              {allCategories.length > 0 && (
+                <div className={styles.tagBar}>
+                  <span className={styles.tagBarLabel}>Tags</span>
+                  <div className={styles.categoryFilterChips}>
+                    <button
+                      className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
+                      onClick={() => setShowUncategorized(prev => !prev)}
+                    >
+                      Untagged
+                    </button>
+                    {allCategories.map(cat => {
+                      const isSelected = selectedCategories.has(cat);
+                      return (
                         <button
-                          className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
-                          onClick={() => setShowUncategorized(prev => !prev)}
+                          key={cat}
+                          className={`${styles.categoryFilterChip} ${isSelected ? styles.categoryFilterChipActive : ''}`}
+                          onClick={() => setSelectedCategories(prev => {
+                            const next = new Set(prev);
+                            if (isSelected) next.delete(cat); else next.add(cat);
+                            return next;
+                          })}
                         >
-                          Untagged
+                          {cat}
                         </button>
-                        {allCategories.map(cat => {
-                          const isSelected = selectedCategories.has(cat);
-                          return (
-                            <button
-                              key={cat}
-                              className={`${styles.categoryFilterChip} ${isSelected ? styles.categoryFilterChipActive : ''}`}
-                              onClick={() => setSelectedCategories(prev => {
-                                const next = new Set(prev);
-                                if (isSelected) next.delete(cat); else next.add(cat);
-                                return next;
-                              })}
-                            >
-                              {cat}
-                            </button>
-                          );
-                        })}
-                        {categoryFilterActive && (
-                          <button
-                            className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
-                            onClick={() => { setSelectedCategories(new Set()); setShowUncategorized(false); }}
-                          >
-                            ✕ Clear
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  )}
+                      );
+                    })}
+                    {categoryFilterActive && (
+                      <button
+                        className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
+                        onClick={() => { setSelectedCategories(new Set()); setShowUncategorized(false); }}
+                      >
+                        ✕ Clear
+                      </button>
+                    )}
+                  </div>
                 </div>
               )}
               <div className={styles.matrix}>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -207,6 +207,7 @@ function MatrixPageContent() {
   const [selectedTodo, setSelectedTodo] = useState<(TodoItem & { id?: string }) | null>(null);
   const [statusFilters, setStatusFilters] = useState<Record<TodoStatus, StatusFilterMode>>(DEFAULT_STATUS_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
+  const [showTags, setShowTags] = useState(true);
   const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [showUncategorized, setShowUncategorized] = useState(false);
@@ -667,39 +668,46 @@ function MatrixPageContent() {
               )}
               {allCategories.length > 0 && (
                 <div className={styles.tagBar}>
-                  <span className={styles.tagBarLabel}>Tags</span>
-                  <div className={styles.categoryFilterChips}>
-                    <button
-                      className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
-                      onClick={() => setShowUncategorized(prev => !prev)}
-                    >
-                      Untagged
-                    </button>
-                    {allCategories.map(cat => {
-                      const isSelected = selectedCategories.has(cat);
-                      return (
-                        <button
-                          key={cat}
-                          className={`${styles.categoryFilterChip} ${isSelected ? styles.categoryFilterChipActive : ''}`}
-                          onClick={() => setSelectedCategories(prev => {
-                            const next = new Set(prev);
-                            if (isSelected) next.delete(cat); else next.add(cat);
-                            return next;
-                          })}
-                        >
-                          {cat}
-                        </button>
-                      );
-                    })}
-                    {categoryFilterActive && (
+                  <button
+                    className={styles.tagBarToggle}
+                    onClick={() => setShowTags(prev => !prev)}
+                  >
+                    {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
+                  </button>
+                  {showTags && (
+                    <div className={styles.categoryFilterChips}>
                       <button
-                        className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
-                        onClick={() => { setSelectedCategories(new Set()); setShowUncategorized(false); }}
+                        className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
+                        onClick={() => setShowUncategorized(prev => !prev)}
                       >
-                        ✕ Clear
+                        Untagged
                       </button>
-                    )}
-                  </div>
+                      {allCategories.map(cat => {
+                        const isSelected = selectedCategories.has(cat);
+                        return (
+                          <button
+                            key={cat}
+                            className={`${styles.categoryFilterChip} ${isSelected ? styles.categoryFilterChipActive : ''}`}
+                            onClick={() => setSelectedCategories(prev => {
+                              const next = new Set(prev);
+                              if (isSelected) next.delete(cat); else next.add(cat);
+                              return next;
+                            })}
+                          >
+                            {cat}
+                          </button>
+                        );
+                      })}
+                      {categoryFilterActive && (
+                        <button
+                          className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
+                          onClick={() => { setSelectedCategories(new Set()); setShowUncategorized(false); }}
+                        >
+                          ✕ Clear
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
               <div className={styles.matrix}>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -560,7 +560,7 @@ function MatrixPageContent() {
     const previousItems = [...todoItems];
     const previousSelectedCategories = new Set(selectedCategories);
     const previousShowUncategorized = showUncategorized;
-    const affectedIds = new Set(affectedItems.map(a => a.id));
+    const affectedIds = new Set(affectedItems.filter(a => a.id).map(a => a.id));
 
     setTodoItems(items =>
       items.map(item =>
@@ -736,6 +736,8 @@ function MatrixPageContent() {
                         className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
                         onClick={() => setShowManageTags(true)}
                         title="Manage tags"
+                        aria-label="Manage tags"
+                        aria-haspopup="dialog"
                       >
                         ⚙
                       </button>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -10,6 +10,7 @@ import { filterArrangeCalendars, getCalendarDisplayName } from '@/lib/calendarUt
 import { getLastBookId, setLastBookId, clearLastBookId, hasSessionSweepRun, isSessionSweepInProgress, markSessionSweepInProgress, clearSessionSweepInProgress, markSessionSweepDone } from '@/lib/bookStorage';
 import AddTodoItem from '@/components/AddTodoItem';
 import ViewTodoItem from '@/components/ViewTodoItem';
+import ManageTags from '@/components/ManageTags';
 import Link from 'next/link';
 import styles from './page.module.css';
 
@@ -211,6 +212,7 @@ function MatrixPageContent() {
   const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [showUncategorized, setShowUncategorized] = useState(false);
+  const [showManageTags, setShowManageTags] = useState(false);
 
   const isAuthenticated = accounts.length > 0;
 
@@ -548,6 +550,94 @@ function MatrixPageContent() {
     }
   };
 
+  const handleDeleteTag = async (tag: string) => {
+    if (!bookId) return;
+
+    const affectedItems = todoItems.filter(item => item.categories?.includes(tag));
+    if (affectedItems.length === 0) return;
+
+    const previousItems = [...todoItems];
+    setTodoItems(items =>
+      items.map(item =>
+        item.categories?.includes(tag)
+          ? { ...item, categories: item.categories.filter(c => c !== tag) }
+          : item
+      )
+    );
+    // Clean up filter state
+    setSelectedCategories(prev => {
+      const next = new Set(prev);
+      next.delete(tag);
+      return next;
+    });
+
+    try {
+      const account = accounts[0];
+      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
+      const CONCURRENCY = 5;
+      let idx = 0;
+      const worker = async () => {
+        while (idx < affectedItems.length) {
+          const item = affectedItems[idx++];
+          if (!item.id) continue;
+          await updateTodoItem(response.accessToken, bookId, item.id, {
+            categories: (item.categories || []).filter(c => c !== tag),
+          });
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
+    } catch (error: any) {
+      console.error('Error deleting tag:', error);
+      setTodoItems(previousItems);
+      throw error;
+    }
+  };
+
+  const handleRenameTag = async (oldTag: string, newTag: string) => {
+    if (!bookId) return;
+
+    const affectedItems = todoItems.filter(item => item.categories?.includes(oldTag));
+    if (affectedItems.length === 0) return;
+
+    const previousItems = [...todoItems];
+    setTodoItems(items =>
+      items.map(item =>
+        item.categories?.includes(oldTag)
+          ? { ...item, categories: item.categories.map(c => c === oldTag ? newTag : c) }
+          : item
+      )
+    );
+    // Update filter state
+    setSelectedCategories(prev => {
+      if (!prev.has(oldTag)) return prev;
+      const next = new Set(prev);
+      next.delete(oldTag);
+      next.add(newTag);
+      return next;
+    });
+
+    try {
+      const account = accounts[0];
+      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
+      const CONCURRENCY = 5;
+      let idx = 0;
+      const worker = async () => {
+        while (idx < affectedItems.length) {
+          const item = affectedItems[idx++];
+          if (!item.id) continue;
+          await updateTodoItem(response.accessToken, bookId, item.id, {
+            categories: (item.categories || []).map(c => c === oldTag ? newTag : c),
+          });
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
+    } catch (error: any) {
+      console.error('Error renaming tag:', error);
+      setTodoItems(previousItems);
+      throw error;
+    }
+  };
+
   const handleLogin = async () => {
     try {
       await instance.loginPopup(loginRequest);
@@ -641,12 +731,21 @@ function MatrixPageContent() {
                 <span className={styles.filterCount}>Showing {filteredTodoItems.length} of {todoItems.length} items</span>
                 <div className={styles.matrixHeaderActions}>
                   {allCategories.length > 0 && (
-                    <button
-                      className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
-                      onClick={() => setShowTags(prev => !prev)}
-                    >
-                      {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
-                    </button>
+                    <>
+                      <button
+                        className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                        onClick={() => setShowTags(prev => !prev)}
+                      >
+                        {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
+                      </button>
+                      <button
+                        className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                        onClick={() => setShowManageTags(true)}
+                        title="Manage tags"
+                      >
+                        ⚙
+                      </button>
+                    </>
                   )}
                   <button
                     className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
@@ -843,6 +942,17 @@ function MatrixPageContent() {
               onClose={() => setSelectedTodo(null)}
               onUpdate={handleUpdateTodo}
               availableCategories={allCategories}
+            />
+          )}
+
+          {/* Manage Tags Dialog */}
+          {showManageTags && (
+            <ManageTags
+              tags={allCategories}
+              todoItems={todoItems}
+              onRenameTag={handleRenameTag}
+              onDeleteTag={handleDeleteTag}
+              onClose={() => setShowManageTags(false)}
             />
           )}
         </div>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -665,13 +665,13 @@ function MatrixPageContent() {
                   ))}
                   {allCategories.length > 0 && (
                     <div className={styles.categoryFilterSection}>
-                      <span className={styles.filterLabel}>Categories</span>
+                      <span className={styles.filterLabel}>Tags</span>
                       <div className={styles.categoryFilterChips}>
                         <button
                           className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
                           onClick={() => setShowUncategorized(prev => !prev)}
                         >
-                          Uncategorized
+                          Untagged
                         </button>
                         {allCategories.map(cat => {
                           const isSelected = selectedCategories.has(cat);

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -208,14 +208,36 @@ function MatrixPageContent() {
   const [statusFilters, setStatusFilters] = useState<Record<TodoStatus, StatusFilterMode>>(DEFAULT_STATUS_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
   const [calendars, setCalendars] = useState<Calendar[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
+  const [showUncategorized, setShowUncategorized] = useState(false);
 
   const isAuthenticated = accounts.length > 0;
+
+  const allCategories = useMemo(() => {
+    const cats = new Set<string>();
+    for (const todo of todoItems) {
+      if (todo.categories) {
+        for (const c of todo.categories) cats.add(c);
+      }
+    }
+    return Array.from(cats).sort((a, b) => a.localeCompare(b));
+  }, [todoItems]);
+
+  const categoryFilterActive = selectedCategories.size > 0 || showUncategorized;
 
   const filteredTodoItems = todoItems.filter(todo => {
     const status = todo.status || 'new';
     const mode = statusFilters[status];
     if (mode === 'hide') return false;
-    if (mode === 'todayOnly') return passesTodayFilter(todo);
+    if (mode === 'todayOnly' && !passesTodayFilter(todo)) return false;
+
+    if (categoryFilterActive) {
+      const hasCats = todo.categories && todo.categories.length > 0;
+      if (showUncategorized && !hasCats) return true;
+      if (hasCats && todo.categories!.some(c => selectedCategories.has(c))) return true;
+      return false;
+    }
+
     return true;
   });
 
@@ -586,7 +608,7 @@ function MatrixPageContent() {
                 </button>
               ) : (
                 <>
-                  <AddTodoItem onAddTodo={handleAddTodo} disabled={loading} />
+                  <AddTodoItem onAddTodo={handleAddTodo} disabled={loading} availableCategories={allCategories} />
                   <button
                     onClick={fetchEvents}
                     disabled={loading}
@@ -641,6 +663,43 @@ function MatrixPageContent() {
                       </div>
                     </div>
                   ))}
+                  {allCategories.length > 0 && (
+                    <div className={styles.categoryFilterSection}>
+                      <span className={styles.filterLabel}>Categories</span>
+                      <div className={styles.categoryFilterChips}>
+                        <button
+                          className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
+                          onClick={() => setShowUncategorized(prev => !prev)}
+                        >
+                          Uncategorized
+                        </button>
+                        {allCategories.map(cat => {
+                          const isSelected = selectedCategories.has(cat);
+                          return (
+                            <button
+                              key={cat}
+                              className={`${styles.categoryFilterChip} ${isSelected ? styles.categoryFilterChipActive : ''}`}
+                              onClick={() => setSelectedCategories(prev => {
+                                const next = new Set(prev);
+                                if (isSelected) next.delete(cat); else next.add(cat);
+                                return next;
+                              })}
+                            >
+                              {cat}
+                            </button>
+                          );
+                        })}
+                        {categoryFilterActive && (
+                          <button
+                            className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
+                            onClick={() => { setSelectedCategories(new Set()); setShowUncategorized(false); }}
+                          >
+                            ✕ Clear
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
               <div className={styles.matrix}>
@@ -661,6 +720,7 @@ function MatrixPageContent() {
                       defaultUrgent={true}
                       defaultImportant={true}
                       compact={true}
+                      availableCategories={allCategories}
                     />
                   </div>
                   <div className={styles.quadrantContent}>
@@ -690,6 +750,7 @@ function MatrixPageContent() {
                       defaultUrgent={false}
                       defaultImportant={true}
                       compact={true}
+                      availableCategories={allCategories}
                     />
                   </div>
                   <div className={styles.quadrantContent}>
@@ -719,6 +780,7 @@ function MatrixPageContent() {
                       defaultUrgent={true}
                       defaultImportant={false}
                       compact={true}
+                      availableCategories={allCategories}
                     />
                   </div>
                   <div className={styles.quadrantContent}>
@@ -748,6 +810,7 @@ function MatrixPageContent() {
                       defaultUrgent={false}
                       defaultImportant={false}
                       compact={true}
+                      availableCategories={allCategories}
                     />
                   </div>
                   <div className={styles.quadrantContent}>
@@ -769,6 +832,7 @@ function MatrixPageContent() {
               todo={selectedTodo} 
               onClose={() => setSelectedTodo(null)}
               onUpdate={handleUpdateTodo}
+              availableCategories={allCategories}
             />
           )}
         </div>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -560,10 +560,11 @@ function MatrixPageContent() {
     const previousItems = [...todoItems];
     const previousSelectedCategories = new Set(selectedCategories);
     const previousShowUncategorized = showUncategorized;
+    const affectedIds = new Set(affectedItems.map(a => a.id));
 
     setTodoItems(items =>
       items.map(item =>
-        affectedItems.some(a => a.id === item.id)
+        affectedIds.has(item.id)
           ? { ...item, categories: computeNewCategories(item) }
           : item
       )

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -638,6 +638,53 @@ function MatrixPageContent() {
     }
   };
 
+  const handleMergeTag = async (sourceTag: string, targetTag: string) => {
+    if (!bookId) return;
+
+    const affectedItems = todoItems.filter(item => item.categories?.includes(sourceTag));
+    if (affectedItems.length === 0) return;
+
+    const previousItems = [...todoItems];
+    setTodoItems(items =>
+      items.map(item => {
+        if (!item.categories?.includes(sourceTag)) return item;
+        const withoutSource = item.categories.filter(c => c !== sourceTag);
+        const merged = withoutSource.includes(targetTag) ? withoutSource : [...withoutSource, targetTag];
+        return { ...item, categories: merged };
+      })
+    );
+    // Update filter state: remove source, keep target
+    setSelectedCategories(prev => {
+      if (!prev.has(sourceTag)) return prev;
+      const next = new Set(prev);
+      next.delete(sourceTag);
+      next.add(targetTag);
+      return next;
+    });
+
+    try {
+      const account = accounts[0];
+      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
+      const CONCURRENCY = 5;
+      let idx = 0;
+      const worker = async () => {
+        while (idx < affectedItems.length) {
+          const item = affectedItems[idx++];
+          if (!item.id) continue;
+          const cats = item.categories || [];
+          const withoutSource = cats.filter(c => c !== sourceTag);
+          const merged = withoutSource.includes(targetTag) ? withoutSource : [...withoutSource, targetTag];
+          await updateTodoItem(response.accessToken, bookId, item.id, { categories: merged });
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
+    } catch (error: any) {
+      console.error('Error merging tags:', error);
+      setTodoItems(previousItems);
+      throw error;
+    }
+  };
+
   const handleLogin = async () => {
     try {
       await instance.loginPopup(loginRequest);
@@ -952,6 +999,7 @@ function MatrixPageContent() {
               todoItems={todoItems}
               onRenameTag={handleRenameTag}
               onDeleteTag={handleDeleteTag}
+              onMergeTag={handleMergeTag}
               onClose={() => setShowManageTags(false)}
             />
           )}

--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -414,6 +414,12 @@
   background-color: #1d4ed8;
 }
 
+.categoryChipStatic {
+  background-color: #2563eb;
+  color: white;
+  cursor: default;
+}
+
 .categoryChipRemove {
   display: inline-flex;
   align-items: center;

--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -373,7 +373,7 @@
   padding: 12px 0;
 }
 
-/* Category picker */
+/* Tag picker */
 .categorySection {
   display: flex;
   flex-direction: column;

--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -373,6 +373,81 @@
   padding: 12px 0;
 }
 
+/* Category picker */
+.categorySection {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.categoryChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.categoryChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 16px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: #dbeafe;
+  color: #1e40af;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.categoryChip:hover {
+  background-color: #bfdbfe;
+}
+
+.categoryChipSelected {
+  background-color: #2563eb;
+  color: white;
+}
+
+.categoryChipSelected:hover {
+  background-color: #1d4ed8;
+}
+
+.categoryChipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.3);
+  color: inherit;
+  font-size: 0.65rem;
+  line-height: 1;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.categoryChipRemove:hover {
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+.categoryAdd {
+  display: flex;
+  gap: 8px;
+}
+
+.categoryAdd .input {
+  flex: 1;
+}
+
+.categoryAddBtn {
+  flex: 0 0 auto !important;
+  width: auto;
+}
+
 .addButtonCompact {
   background-color: rgba(255, 255, 255, 0.9);
   color: inherit;

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { TodoItem, TodoStatus } from '@/lib/todoDataService';
+import TagPicker from './TagPicker';
 import styles from './AddTodoItem.module.css';
 
 interface AddTodoItemProps {
@@ -42,7 +43,6 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
   const [etaDateTime, setEtaDateTime] = useState(() => getDateTimeString(24)); // 24 hours from now
   const [etsDateTime, setEtsDateTime] = useState(() => getDateTimeString());
   const [categories, setCategories] = useState<string[]>([]);
-  const [newCategory, setNewCategory] = useState('');
   type AddTab = 'essentials' | 'tags' | 'remarks' | 'checklist';
   const [activeTab, setActiveTab] = useState<AddTab>('essentials');
 
@@ -57,7 +57,6 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
     setEtaDateTime(getDateTimeString(24)); // 24 hours from now
     setEtsDateTime(getDateTimeString());
     setCategories([]);
-    setNewCategory('');
     setActiveTab('essentials');
     setError(null);
   };
@@ -221,70 +220,12 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
 
           {activeTab === 'tags' && (
             <div className={styles.tabContent}>
-              <div className={styles.categorySection}>
-                <label className={styles.label}>Tags</label>
-                {(availableCategories.length > 0 || categories.length > 0) && (
-                  <div className={styles.categoryChips}>
-                    {availableCategories.filter(c => !categories.includes(c)).map(cat => (
-                      <button
-                        key={cat}
-                        type="button"
-                        className={styles.categoryChip}
-                        disabled={isSubmitting}
-                        onClick={() => setCategories(prev => [...prev, cat])}
-                      >
-                        {cat}
-                      </button>
-                    ))}
-                    {categories.map(cat => (
-                      <button
-                        key={cat}
-                        type="button"
-                        className={`${styles.categoryChip} ${styles.categoryChipSelected}`}
-                        disabled={isSubmitting}
-                        onClick={() => setCategories(prev => prev.filter(c => c !== cat))}
-                      >
-                        {cat}
-                        <span className={styles.categoryChipRemove}>✕</span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-                <div className={styles.categoryAdd}>
-                  <input
-                    type="text"
-                    value={newCategory}
-                    onChange={(e) => setNewCategory(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && newCategory.trim()) {
-                        e.preventDefault();
-                        const cat = newCategory.trim();
-                        if (!categories.includes(cat)) {
-                          setCategories(prev => [...prev, cat]);
-                        }
-                        setNewCategory('');
-                      }
-                    }}
-                    placeholder="Add new tag..."
-                    className={styles.input}
-                    disabled={isSubmitting}
-                  />
-                  <button
-                    type="button"
-                    className={`${styles.button} ${styles.buttonSecondary} ${styles.categoryAddBtn}`}
-                    disabled={isSubmitting || !newCategory.trim()}
-                    onClick={() => {
-                      const cat = newCategory.trim();
-                      if (cat && !categories.includes(cat)) {
-                        setCategories(prev => [...prev, cat]);
-                      }
-                      setNewCategory('');
-                    }}
-                  >
-                    Add
-                  </button>
-                </div>
-              </div>
+              <TagPicker
+                availableCategories={availableCategories}
+                categories={categories}
+                onChange={setCategories}
+                disabled={isSubmitting}
+              />
             </div>
           )}
 

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -204,7 +204,7 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
               </div>
 
               <div className={styles.categorySection}>
-                <label className={styles.label}>Categories</label>
+                <label className={styles.label}>Tags</label>
                 {(availableCategories.length > 0 || categories.length > 0) && (
                   <div className={styles.categoryChips}>
                     {availableCategories.filter(c => !categories.includes(c)).map(cat => (
@@ -247,7 +247,7 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
                         setNewCategory('');
                       }
                     }}
-                    placeholder="Add new category..."
+                    placeholder="Add new tag..."
                     className={styles.input}
                     disabled={isSubmitting}
                   />

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -11,9 +11,10 @@ interface AddTodoItemProps {
   defaultImportant?: boolean;
   buttonText?: string;
   compact?: boolean;
+  availableCategories?: string[];
 }
 
-export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false, defaultImportant = false, buttonText = 'Add TODO', compact = false }: AddTodoItemProps) {
+export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false, defaultImportant = false, buttonText = 'Add TODO', compact = false, availableCategories = [] }: AddTodoItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -40,6 +41,8 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
   const [newChecklistItem, setNewChecklistItem] = useState('');
   const [etaDateTime, setEtaDateTime] = useState(() => getDateTimeString(24)); // 24 hours from now
   const [etsDateTime, setEtsDateTime] = useState(() => getDateTimeString());
+  const [categories, setCategories] = useState<string[]>([]);
+  const [newCategory, setNewCategory] = useState('');
   type AddTab = 'essentials' | 'remarks' | 'checklist';
   const [activeTab, setActiveTab] = useState<AddTab>('essentials');
 
@@ -53,6 +56,8 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
     setNewChecklistItem('');
     setEtaDateTime(getDateTimeString(24)); // 24 hours from now
     setEtsDateTime(getDateTimeString());
+    setCategories([]);
+    setNewCategory('');
     setActiveTab('essentials');
     setError(null);
   };
@@ -91,6 +96,7 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
           content: remarks.trim(),
         } : undefined,
         checklist: checklist.length > 0 ? checklist : undefined,
+        categories: categories.length > 0 ? categories : undefined,
       };
 
       await onAddTodo(todoItem);
@@ -195,6 +201,71 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
                 <input type="datetime-local" id="etaDateTime" value={etaDateTime}
                   onChange={(e) => setEtaDateTime(e.target.value)}
                   disabled={isSubmitting} className={styles.input} />
+              </div>
+
+              <div className={styles.categorySection}>
+                <label className={styles.label}>Categories</label>
+                {(availableCategories.length > 0 || categories.length > 0) && (
+                  <div className={styles.categoryChips}>
+                    {availableCategories.filter(c => !categories.includes(c)).map(cat => (
+                      <button
+                        key={cat}
+                        type="button"
+                        className={styles.categoryChip}
+                        disabled={isSubmitting}
+                        onClick={() => setCategories(prev => [...prev, cat])}
+                      >
+                        {cat}
+                      </button>
+                    ))}
+                    {categories.map(cat => (
+                      <button
+                        key={cat}
+                        type="button"
+                        className={`${styles.categoryChip} ${styles.categoryChipSelected}`}
+                        disabled={isSubmitting}
+                        onClick={() => setCategories(prev => prev.filter(c => c !== cat))}
+                      >
+                        {cat}
+                        <span className={styles.categoryChipRemove}>✕</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+                <div className={styles.categoryAdd}>
+                  <input
+                    type="text"
+                    value={newCategory}
+                    onChange={(e) => setNewCategory(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && newCategory.trim()) {
+                        e.preventDefault();
+                        const cat = newCategory.trim();
+                        if (!categories.includes(cat)) {
+                          setCategories(prev => [...prev, cat]);
+                        }
+                        setNewCategory('');
+                      }
+                    }}
+                    placeholder="Add new category..."
+                    className={styles.input}
+                    disabled={isSubmitting}
+                  />
+                  <button
+                    type="button"
+                    className={`${styles.button} ${styles.buttonSecondary} ${styles.categoryAddBtn}`}
+                    disabled={isSubmitting || !newCategory.trim()}
+                    onClick={() => {
+                      const cat = newCategory.trim();
+                      if (cat && !categories.includes(cat)) {
+                        setCategories(prev => [...prev, cat]);
+                      }
+                      setNewCategory('');
+                    }}
+                  >
+                    Add
+                  </button>
+                </div>
               </div>
 
               <div className={styles.preview}>

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -43,7 +43,7 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
   const [etsDateTime, setEtsDateTime] = useState(() => getDateTimeString());
   const [categories, setCategories] = useState<string[]>([]);
   const [newCategory, setNewCategory] = useState('');
-  type AddTab = 'essentials' | 'remarks' | 'checklist';
+  type AddTab = 'essentials' | 'tags' | 'remarks' | 'checklist';
   const [activeTab, setActiveTab] = useState<AddTab>('essentials');
 
   const resetForm = () => {
@@ -146,6 +146,8 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
           <div className={styles.tabBar}>
             <button type="button" className={`${styles.tab} ${activeTab === 'essentials' ? styles.tabActive : ''}`}
               onClick={() => setActiveTab('essentials')}>Essentials</button>
+            <button type="button" className={`${styles.tab} ${activeTab === 'tags' ? styles.tabActive : ''}`}
+              onClick={() => setActiveTab('tags')}>Tags</button>
             <button type="button" className={`${styles.tab} ${activeTab === 'remarks' ? styles.tabActive : ''}`}
               onClick={() => setActiveTab('remarks')}>Remarks</button>
             <button type="button" className={`${styles.tab} ${activeTab === 'checklist' ? styles.tabActive : ''}`}
@@ -203,6 +205,22 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
                   disabled={isSubmitting} className={styles.input} />
               </div>
 
+              <div className={styles.preview}>
+                <p className={styles.previewText}>
+                  Matrix Quadrant:{' '}
+                  <span className={styles.previewLabel}>
+                    {urgent && important && '🔴 Do First (Urgent & Important)'}
+                    {!urgent && important && '🟡 Schedule (Important, Not Urgent)'}
+                    {urgent && !important && '🟠 Delegate (Urgent, Not Important)'}
+                    {!urgent && !important && '⚪ Eliminate (Neither)'}
+                  </span>
+                </p>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'tags' && (
+            <div className={styles.tabContent}>
               <div className={styles.categorySection}>
                 <label className={styles.label}>Tags</label>
                 {(availableCategories.length > 0 || categories.length > 0) && (
@@ -266,18 +284,6 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
                     Add
                   </button>
                 </div>
-              </div>
-
-              <div className={styles.preview}>
-                <p className={styles.previewText}>
-                  Matrix Quadrant:{' '}
-                  <span className={styles.previewLabel}>
-                    {urgent && important && '🔴 Do First (Urgent & Important)'}
-                    {!urgent && important && '🟡 Schedule (Important, Not Urgent)'}
-                    {urgent && !important && '🟠 Delegate (Urgent, Not Important)'}
-                    {!urgent && !important && '⚪ Eliminate (Neither)'}
-                  </span>
-                </p>
               </div>
             </div>
           )}

--- a/src/arrange-v4/components/ManageTags.module.css
+++ b/src/arrange-v4/components/ManageTags.module.css
@@ -1,0 +1,262 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  padding: 24px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 80vh;
+  margin: 0 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 16px;
+  color: #111827;
+}
+
+.tagList {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tagRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  transition: background-color 0.1s;
+}
+
+.tagRow:hover {
+  background-color: #f9fafb;
+}
+
+.tagName {
+  flex: 1;
+  font-size: 0.95rem;
+  color: #111827;
+  font-weight: 500;
+}
+
+.tagCount {
+  font-size: 0.75rem;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.tagActions {
+  display: flex;
+  gap: 4px;
+}
+
+.iconButton {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  color: #6b7280;
+  transition: all 0.15s;
+}
+
+.iconButton:hover {
+  background-color: #f3f4f6;
+  border-color: #d1d5db;
+  color: #374151;
+}
+
+.iconButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.iconButtonDanger:hover {
+  background-color: #fef2f2;
+  border-color: #fca5a5;
+  color: #dc2626;
+}
+
+/* Rename inline form */
+.renameRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background-color: #eff6ff;
+  border-radius: 6px;
+}
+
+.renameInput {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid #93c5fd;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.renameInput:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.renameActions {
+  display: flex;
+  gap: 4px;
+}
+
+.renameBtn {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all 0.15s;
+}
+
+.renameSave {
+  background-color: #2563eb;
+  color: white;
+}
+
+.renameSave:hover {
+  background-color: #1d4ed8;
+}
+
+.renameSave:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.renameCancel {
+  background-color: transparent;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+}
+
+.renameCancel:hover {
+  background-color: #f9fafb;
+}
+
+/* Confirm delete */
+.confirmRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background-color: #fef2f2;
+  border-radius: 6px;
+}
+
+.confirmText {
+  flex: 1;
+  font-size: 0.85rem;
+  color: #991b1b;
+}
+
+.confirmActions {
+  display: flex;
+  gap: 4px;
+}
+
+.confirmDelete {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  background-color: #dc2626;
+  color: white;
+  transition: all 0.15s;
+}
+
+.confirmDelete:hover {
+  background-color: #b91c1c;
+}
+
+.confirmDelete:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.confirmCancel {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  transition: all 0.15s;
+}
+
+.confirmCancel:hover {
+  background-color: #f9fafb;
+}
+
+/* Footer */
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+  margin-top: 16px;
+}
+
+.closeButton {
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid #d1d5db;
+  background-color: transparent;
+  color: #374151;
+  font-size: 0.95rem;
+  transition: all 0.15s;
+}
+
+.closeButton:hover {
+  background-color: #f9fafb;
+}
+
+.error {
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  font-size: 0.85rem;
+}
+
+.empty {
+  color: #9ca3af;
+  font-size: 0.9rem;
+  font-style: italic;
+  padding: 24px 0;
+  text-align: center;
+}

--- a/src/arrange-v4/components/ManageTags.module.css
+++ b/src/arrange-v4/components/ManageTags.module.css
@@ -14,7 +14,7 @@
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
   padding: 24px;
   width: 100%;
-  max-width: 480px;
+  max-width: 640px;
   max-height: 80vh;
   margin: 0 16px;
   display: flex;

--- a/src/arrange-v4/components/ManageTags.module.css
+++ b/src/arrange-v4/components/ManageTags.module.css
@@ -163,6 +163,7 @@
 .mergeRow {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 8px 10px;
   background-color: #f0fdf4;
@@ -176,13 +177,14 @@
 }
 
 .mergeSelect {
-  flex: 1;
+  min-width: 120px;
   padding: 4px 8px;
   border: 1px solid #86efac;
   border-radius: 4px;
   font-size: 0.85rem;
   outline: none;
   background-color: white;
+  color: #111827;
 }
 
 .mergeSelect:focus {

--- a/src/arrange-v4/components/ManageTags.module.css
+++ b/src/arrange-v4/components/ManageTags.module.css
@@ -159,6 +159,37 @@
   background-color: #f9fafb;
 }
 
+/* Merge row */
+.mergeRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background-color: #f0fdf4;
+  border-radius: 6px;
+}
+
+.mergeText {
+  font-size: 0.85rem;
+  color: #166534;
+  white-space: nowrap;
+}
+
+.mergeSelect {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid #86efac;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  outline: none;
+  background-color: white;
+}
+
+.mergeSelect:focus {
+  border-color: #22c55e;
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.15);
+}
+
 /* Confirm delete */
 .confirmRow {
   display: flex;

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -9,24 +9,33 @@ interface ManageTagsProps {
   todoItems: (TodoItem & { id?: string })[];
   onRenameTag: (oldTag: string, newTag: string) => Promise<void>;
   onDeleteTag: (tag: string) => Promise<void>;
+  onMergeTag: (sourceTag: string, targetTag: string) => Promise<void>;
   onClose: () => void;
 }
 
-export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, onClose }: ManageTagsProps) {
+export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, onMergeTag, onClose }: ManageTagsProps) {
   const [renamingTag, setRenamingTag] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [deletingTag, setDeletingTag] = useState<string | null>(null);
+  const [mergingTag, setMergingTag] = useState<string | null>(null);
+  const [mergeTarget, setMergeTarget] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const getItemCount = (tag: string) =>
     todoItems.filter(item => item.categories?.includes(tag)).length;
 
+  const clearActions = () => {
+    setRenamingTag(null);
+    setDeletingTag(null);
+    setMergingTag(null);
+    setError(null);
+  };
+
   const startRename = (tag: string) => {
+    clearActions();
     setRenamingTag(tag);
     setRenameValue(tag);
-    setDeletingTag(null);
-    setError(null);
   };
 
   const handleRename = async () => {
@@ -51,9 +60,8 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
   };
 
   const startDelete = (tag: string) => {
+    clearActions();
     setDeletingTag(tag);
-    setRenamingTag(null);
-    setError(null);
   };
 
   const handleDelete = async () => {
@@ -66,6 +74,28 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
       setDeletingTag(null);
     } catch (err: any) {
       setError(err.message || 'Failed to delete tag');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const startMerge = (tag: string) => {
+    clearActions();
+    setMergingTag(tag);
+    const otherTags = tags.filter(t => t !== tag);
+    setMergeTarget(otherTags[0] || '');
+  };
+
+  const handleMerge = async () => {
+    if (!mergingTag || !mergeTarget) return;
+
+    setBusy(true);
+    setError(null);
+    try {
+      await onMergeTag(mergingTag, mergeTarget);
+      setMergingTag(null);
+    } catch (err: any) {
+      setError(err.message || 'Failed to merge tags');
     } finally {
       setBusy(false);
     }
@@ -147,6 +177,43 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
               );
             }
 
+            if (mergingTag === tag) {
+              const otherTags = tags.filter(t => t !== tag);
+              return (
+                <div key={tag} className={styles.mergeRow}>
+                  <span className={styles.mergeText}>
+                    Merge &ldquo;{tag}&rdquo; into
+                  </span>
+                  <select
+                    className={styles.mergeSelect}
+                    value={mergeTarget}
+                    onChange={(e) => setMergeTarget(e.target.value)}
+                    disabled={busy}
+                  >
+                    {otherTags.map(t => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                  <div className={styles.confirmActions}>
+                    <button
+                      className={`${styles.renameBtn} ${styles.renameSave}`}
+                      onClick={handleMerge}
+                      disabled={busy || !mergeTarget}
+                    >
+                      {busy ? '...' : 'Merge'}
+                    </button>
+                    <button
+                      className={`${styles.renameBtn} ${styles.renameCancel}`}
+                      onClick={() => setMergingTag(null)}
+                      disabled={busy}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+
             return (
               <div key={tag} className={styles.tagRow}>
                 <span className={styles.tagName}>{tag}</span>
@@ -160,6 +227,16 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
                   >
                     ✏️
                   </button>
+                  {tags.length > 1 && (
+                    <button
+                      className={styles.iconButton}
+                      onClick={() => startMerge(tag)}
+                      disabled={busy}
+                      title="Merge into another tag"
+                    >
+                      🔀
+                    </button>
+                  )}
                   <button
                     className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                     onClick={() => startDelete(tag)}

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -237,6 +237,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
                     onClick={() => startRename(tag)}
                     disabled={busy}
                     title="Rename tag"
+                    aria-label={`Rename tag ${tag}`}
                   >
                     ✏️
                   </button>
@@ -246,6 +247,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
                       onClick={() => startMerge(tag)}
                       disabled={busy}
                       title="Merge into another tag"
+                      aria-label={`Merge tag ${tag} into another`}
                     >
                       🔀
                     </button>
@@ -255,6 +257,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
                     onClick={() => startDelete(tag)}
                     disabled={busy}
                     title="Delete tag"
+                    aria-label={`Delete tag ${tag}`}
                   >
                     🗑️
                   </button>

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState } from 'react';
+import { TodoItem } from '@/lib/todoDataService';
+import styles from './ManageTags.module.css';
+
+interface ManageTagsProps {
+  tags: string[];
+  todoItems: (TodoItem & { id?: string })[];
+  onRenameTag: (oldTag: string, newTag: string) => Promise<void>;
+  onDeleteTag: (tag: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, onClose }: ManageTagsProps) {
+  const [renamingTag, setRenamingTag] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [deletingTag, setDeletingTag] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getItemCount = (tag: string) =>
+    todoItems.filter(item => item.categories?.includes(tag)).length;
+
+  const startRename = (tag: string) => {
+    setRenamingTag(tag);
+    setRenameValue(tag);
+    setDeletingTag(null);
+    setError(null);
+  };
+
+  const handleRename = async () => {
+    if (!renamingTag || !renameValue.trim()) return;
+    const newTag = renameValue.trim();
+    if (newTag === renamingTag) { setRenamingTag(null); return; }
+    if (tags.includes(newTag)) {
+      setError(`Tag "${newTag}" already exists`);
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      await onRenameTag(renamingTag, newTag);
+      setRenamingTag(null);
+    } catch (err: any) {
+      setError(err.message || 'Failed to rename tag');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const startDelete = (tag: string) => {
+    setDeletingTag(tag);
+    setRenamingTag(null);
+    setError(null);
+  };
+
+  const handleDelete = async () => {
+    if (!deletingTag) return;
+
+    setBusy(true);
+    setError(null);
+    try {
+      await onDeleteTag(deletingTag);
+      setDeletingTag(null);
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete tag');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <h2 className={styles.title}>Manage Tags</h2>
+
+        {error && (
+          <div className={styles.error} role="alert">{error}</div>
+        )}
+
+        <div className={styles.tagList}>
+          {tags.length === 0 && (
+            <p className={styles.empty}>No tags yet</p>
+          )}
+          {tags.map(tag => {
+            const count = getItemCount(tag);
+
+            if (renamingTag === tag) {
+              return (
+                <div key={tag} className={styles.renameRow}>
+                  <input
+                    className={styles.renameInput}
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleRename();
+                      if (e.key === 'Escape') setRenamingTag(null);
+                    }}
+                    disabled={busy}
+                    autoFocus
+                  />
+                  <div className={styles.renameActions}>
+                    <button
+                      className={`${styles.renameBtn} ${styles.renameSave}`}
+                      onClick={handleRename}
+                      disabled={busy || !renameValue.trim() || renameValue.trim() === tag}
+                    >
+                      {busy ? '...' : 'Save'}
+                    </button>
+                    <button
+                      className={`${styles.renameBtn} ${styles.renameCancel}`}
+                      onClick={() => setRenamingTag(null)}
+                      disabled={busy}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+
+            if (deletingTag === tag) {
+              return (
+                <div key={tag} className={styles.confirmRow}>
+                  <span className={styles.confirmText}>
+                    Remove &ldquo;{tag}&rdquo; from {count} item{count !== 1 ? 's' : ''}?
+                  </span>
+                  <div className={styles.confirmActions}>
+                    <button
+                      className={styles.confirmDelete}
+                      onClick={handleDelete}
+                      disabled={busy}
+                    >
+                      {busy ? '...' : 'Delete'}
+                    </button>
+                    <button
+                      className={styles.confirmCancel}
+                      onClick={() => setDeletingTag(null)}
+                      disabled={busy}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              );
+            }
+
+            return (
+              <div key={tag} className={styles.tagRow}>
+                <span className={styles.tagName}>{tag}</span>
+                <span className={styles.tagCount}>{count} item{count !== 1 ? 's' : ''}</span>
+                <div className={styles.tagActions}>
+                  <button
+                    className={styles.iconButton}
+                    onClick={() => startRename(tag)}
+                    disabled={busy}
+                    title="Rename tag"
+                  >
+                    ✏️
+                  </button>
+                  <button
+                    className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+                    onClick={() => startDelete(tag)}
+                    disabled={busy}
+                    title="Delete tag"
+                  >
+                    🗑️
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className={styles.footer}>
+          <button className={styles.closeButton} onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -42,7 +42,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
     if (!renamingTag || !renameValue.trim()) return;
     const newTag = renameValue.trim();
     if (newTag === renamingTag) { setRenamingTag(null); return; }
-    if (tags.includes(newTag)) {
+    if (tags.some(t => t.toLowerCase() === newTag.toLowerCase() && t !== renamingTag)) {
       setError(`Tag "${newTag}" already exists`);
       return;
     }

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { TodoItem } from '@/lib/todoDataService';
 import styles from './ManageTags.module.css';
 
@@ -22,8 +22,21 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const getItemCount = (tag: string) =>
-    todoItems.filter(item => item.categories?.includes(tag)).length;
+  const tagCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of todoItems) {
+      if (item.categories) {
+        for (const c of item.categories) {
+          counts.set(c, (counts.get(c) || 0) + 1);
+        }
+      }
+    }
+    return counts;
+  }, [todoItems]);
+
+  const handleClose = () => {
+    if (!busy) onClose();
+  };
 
   const clearActions = () => {
     setRenamingTag(null);
@@ -102,9 +115,9 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
   };
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <h2 className={styles.title}>Manage Tags</h2>
+    <div className={styles.overlay} onClick={handleClose}>
+      <div className={styles.modal} role="dialog" aria-modal="true" aria-labelledby="manage-tags-title" onClick={(e) => e.stopPropagation()}>
+        <h2 id="manage-tags-title" className={styles.title}>Manage Tags</h2>
 
         {error && (
           <div className={styles.error} role="alert">{error}</div>
@@ -115,7 +128,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
             <p className={styles.empty}>No tags yet</p>
           )}
           {tags.map(tag => {
-            const count = getItemCount(tag);
+            const count = tagCounts.get(tag) || 0;
 
             if (renamingTag === tag) {
               return (
@@ -252,7 +265,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
         </div>
 
         <div className={styles.footer}>
-          <button className={styles.closeButton} onClick={onClose}>
+          <button className={styles.closeButton} onClick={handleClose} disabled={busy}>
             Close
           </button>
         </div>

--- a/src/arrange-v4/components/TagPicker.tsx
+++ b/src/arrange-v4/components/TagPicker.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './AddTodoItem.module.css';
+
+interface TagPickerProps {
+  availableCategories: string[];
+  categories: string[];
+  onChange: (categories: string[]) => void;
+  disabled?: boolean;
+}
+
+export default function TagPicker({ availableCategories, categories, onChange, disabled = false }: TagPickerProps) {
+  const [newCategory, setNewCategory] = useState('');
+
+  const addCategory = (cat: string) => {
+    if (!categories.includes(cat)) {
+      onChange([...categories, cat]);
+    }
+  };
+
+  const removeCategory = (cat: string) => {
+    onChange(categories.filter(c => c !== cat));
+  };
+
+  const handleAddNew = () => {
+    const cat = newCategory.trim();
+    if (cat) {
+      addCategory(cat);
+      setNewCategory('');
+    }
+  };
+
+  return (
+    <div className={styles.categorySection}>
+      <label className={styles.label}>Tags</label>
+      {(availableCategories.length > 0 || categories.length > 0) && (
+        <div className={styles.categoryChips}>
+          {availableCategories.filter(c => !categories.includes(c)).map(cat => (
+            <button
+              key={cat}
+              type="button"
+              className={styles.categoryChip}
+              disabled={disabled}
+              onClick={() => addCategory(cat)}
+            >
+              {cat}
+            </button>
+          ))}
+          {categories.map(cat => (
+            <button
+              key={cat}
+              type="button"
+              className={`${styles.categoryChip} ${styles.categoryChipSelected}`}
+              disabled={disabled}
+              onClick={() => removeCategory(cat)}
+            >
+              {cat}
+              <span className={styles.categoryChipRemove}>✕</span>
+            </button>
+          ))}
+        </div>
+      )}
+      <div className={styles.categoryAdd}>
+        <input
+          type="text"
+          value={newCategory}
+          onChange={(e) => setNewCategory(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && newCategory.trim()) {
+              e.preventDefault();
+              handleAddNew();
+            }
+          }}
+          placeholder="Add new tag..."
+          className={styles.input}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          className={`${styles.button} ${styles.buttonSecondary} ${styles.categoryAddBtn}`}
+          disabled={disabled || !newCategory.trim()}
+          onClick={handleAddNew}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/arrange-v4/components/TagPicker.tsx
+++ b/src/arrange-v4/components/TagPicker.tsx
@@ -14,7 +14,7 @@ export default function TagPicker({ availableCategories, categories, onChange, d
   const [newCategory, setNewCategory] = useState('');
 
   const addCategory = (cat: string) => {
-    if (!categories.includes(cat)) {
+    if (!categories.some(c => c.toLowerCase() === cat.toLowerCase())) {
       onChange([...categories, cat]);
     }
   };
@@ -36,7 +36,7 @@ export default function TagPicker({ availableCategories, categories, onChange, d
       <label className={styles.label}>Tags</label>
       {(availableCategories.length > 0 || categories.length > 0) && (
         <div className={styles.categoryChips}>
-          {availableCategories.filter(c => !categories.includes(c)).map(cat => (
+          {availableCategories.filter(c => !categories.some(sel => sel.toLowerCase() === c.toLowerCase())).map(cat => (
             <button
               key={cat}
               type="button"

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -347,8 +347,8 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                 <div className={styles.formGroup}>
                   <span className={styles.label}>Tags</span>
                   <div className={styles.categoryChips}>
-                    {todo.categories.map((cat, idx) => (
-                      <span key={idx} className={`${styles.categoryChip} ${styles.categoryChipSelected}`}>
+                    {todo.categories.map((cat) => (
+                      <span key={cat} className={`${styles.categoryChip} ${styles.categoryChipSelected}`}>
                         {cat}
                       </span>
                     ))}

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -179,7 +179,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                 </div>
 
                 <div className={styles.categorySection}>
-                  <label className={styles.label}>Categories</label>
+                  <label className={styles.label}>Tags</label>
                   {(availableCategories.length > 0 || categories.length > 0) && (
                     <div className={styles.categoryChips}>
                       {availableCategories.filter(c => !categories.includes(c)).map(cat => (
@@ -222,7 +222,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                           setNewCategory('');
                         }
                       }}
-                      placeholder="Add new category..."
+                      placeholder="Add new tag..."
                       className={styles.input}
                       disabled={isSubmitting}
                     />
@@ -385,7 +385,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
 
               {todo.categories && todo.categories.length > 0 && (
                 <div className={styles.formGroup}>
-                  <span className={styles.label}>Categories</span>
+                  <span className={styles.label}>Tags</span>
                   <span className={styles.value}>{todo.categories.join(', ')}</span>
                 </div>
               )}

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { TodoItem, TodoStatus, STATUS_LABELS } from '@/lib/todoDataService';
+import TagPicker from './TagPicker';
 import styles from './AddTodoItem.module.css';
 
 interface ViewTodoItemProps {
@@ -38,7 +39,6 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
   const [checklist, setChecklist] = useState<string[]>(todo.checklist || []);
   const [newChecklistItem, setNewChecklistItem] = useState('');
   const [categories, setCategories] = useState<string[]>(todo.categories || []);
-  const [newCategory, setNewCategory] = useState('');
 
   const getQuadrantLabel = (u: boolean, i: boolean) => {
     if (u && i) return '🔴 Do First (Urgent & Important)';
@@ -102,7 +102,6 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
     setChecklist(todo.checklist || []);
     setNewChecklistItem('');
     setCategories(todo.categories || []);
-    setNewCategory('');
     setError(null);
     setEditing(false);
   };
@@ -191,70 +190,12 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
 
             {activeTab === 'tags' && (
               <div className={styles.tabContent}>
-                <div className={styles.categorySection}>
-                  <label className={styles.label}>Tags</label>
-                  {(availableCategories.length > 0 || categories.length > 0) && (
-                    <div className={styles.categoryChips}>
-                      {availableCategories.filter(c => !categories.includes(c)).map(cat => (
-                        <button
-                          key={cat}
-                          type="button"
-                          className={styles.categoryChip}
-                          disabled={isSubmitting}
-                          onClick={() => setCategories(prev => [...prev, cat])}
-                        >
-                          {cat}
-                        </button>
-                      ))}
-                      {categories.map(cat => (
-                        <button
-                          key={cat}
-                          type="button"
-                          className={`${styles.categoryChip} ${styles.categoryChipSelected}`}
-                          disabled={isSubmitting}
-                          onClick={() => setCategories(prev => prev.filter(c => c !== cat))}
-                        >
-                          {cat}
-                          <span className={styles.categoryChipRemove}>✕</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  <div className={styles.categoryAdd}>
-                    <input
-                      type="text"
-                      value={newCategory}
-                      onChange={(e) => setNewCategory(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newCategory.trim()) {
-                          e.preventDefault();
-                          const cat = newCategory.trim();
-                          if (!categories.includes(cat)) {
-                            setCategories(prev => [...prev, cat]);
-                          }
-                          setNewCategory('');
-                        }
-                      }}
-                      placeholder="Add new tag..."
-                      className={styles.input}
-                      disabled={isSubmitting}
-                    />
-                    <button
-                      type="button"
-                      className={`${styles.button} ${styles.buttonSecondary} ${styles.categoryAddBtn}`}
-                      disabled={isSubmitting || !newCategory.trim()}
-                      onClick={() => {
-                        const cat = newCategory.trim();
-                        if (cat && !categories.includes(cat)) {
-                          setCategories(prev => [...prev, cat]);
-                        }
-                        setNewCategory('');
-                      }}
-                    >
-                      Add
-                    </button>
-                  </div>
-                </div>
+                <TagPicker
+                  availableCategories={availableCategories}
+                  categories={categories}
+                  onChange={setCategories}
+                  disabled={isSubmitting}
+                />
               </div>
             )}
 

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -11,7 +11,7 @@ interface ViewTodoItemProps {
   availableCategories?: string[];
 }
 
-type ViewTab = 'essentials' | 'remarks' | 'checklist';
+type ViewTab = 'essentials' | 'tags' | 'remarks' | 'checklist';
 
 export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategories = [] }: ViewTodoItemProps) {
   const [editing, setEditing] = useState(false);
@@ -121,6 +121,8 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
             <div className={styles.tabBar}>
               <button type="button" className={`${styles.tab} ${activeTab === 'essentials' ? styles.tabActive : ''}`}
                 onClick={() => setActiveTab('essentials')}>Essentials</button>
+              <button type="button" className={`${styles.tab} ${activeTab === 'tags' ? styles.tabActive : ''}`}
+                onClick={() => setActiveTab('tags')}>Tags</button>
               <button type="button" className={`${styles.tab} ${activeTab === 'remarks' ? styles.tabActive : ''}`}
                 onClick={() => setActiveTab('remarks')}>Remarks</button>
               <button type="button" className={`${styles.tab} ${activeTab === 'checklist' ? styles.tabActive : ''}`}
@@ -178,6 +180,17 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                     disabled={isSubmitting} className={styles.input} />
                 </div>
 
+                <div className={styles.preview}>
+                  <p className={styles.previewText}>
+                    Matrix Quadrant:{' '}
+                    <span className={styles.previewLabel}>{getQuadrantLabel(urgent, important)}</span>
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'tags' && (
+              <div className={styles.tabContent}>
                 <div className={styles.categorySection}>
                   <label className={styles.label}>Tags</label>
                   {(availableCategories.length > 0 || categories.length > 0) && (
@@ -241,13 +254,6 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                       Add
                     </button>
                   </div>
-                </div>
-
-                <div className={styles.preview}>
-                  <p className={styles.previewText}>
-                    Matrix Quadrant:{' '}
-                    <span className={styles.previewLabel}>{getQuadrantLabel(urgent, important)}</span>
-                  </p>
                 </div>
               </div>
             )}
@@ -345,6 +351,8 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
           <div className={styles.tabBar}>
             <button type="button" className={`${styles.tab} ${activeTab === 'essentials' ? styles.tabActive : ''}`}
               onClick={() => setActiveTab('essentials')}>Essentials</button>
+            <button type="button" className={`${styles.tab} ${activeTab === 'tags' ? styles.tabActive : ''}`}
+              onClick={() => setActiveTab('tags')}>Tags</button>
             <button type="button" className={`${styles.tab} ${activeTab === 'remarks' ? styles.tabActive : ''}`}
               onClick={() => setActiveTab('remarks')}>Remarks</button>
             <button type="button" className={`${styles.tab} ${activeTab === 'checklist' ? styles.tabActive : ''}`}
@@ -383,19 +391,31 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                 <span className={styles.value}>{formatDateTime(todo.etaDateTime)}</span>
               </div>
 
-              {todo.categories && todo.categories.length > 0 && (
-                <div className={styles.formGroup}>
-                  <span className={styles.label}>Tags</span>
-                  <span className={styles.value}>{todo.categories.join(', ')}</span>
-                </div>
-              )}
-
               <div className={styles.preview}>
                 <p className={styles.previewText}>
                   Matrix Quadrant:{' '}
                   <span className={styles.previewLabel}>{getQuadrantLabel(todo.urgent ?? false, todo.important ?? false)}</span>
                 </p>
               </div>
+            </div>
+          )}
+
+          {activeTab === 'tags' && (
+            <div className={styles.tabContent}>
+              {todo.categories && todo.categories.length > 0 ? (
+                <div className={styles.formGroup}>
+                  <span className={styles.label}>Tags</span>
+                  <div className={styles.categoryChips}>
+                    {todo.categories.map((cat, idx) => (
+                      <span key={idx} className={`${styles.categoryChip} ${styles.categoryChipSelected}`}>
+                        {cat}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <p className={styles.tabPlaceholder}>No tags</p>
+              )}
             </div>
           )}
 

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -8,11 +8,12 @@ interface ViewTodoItemProps {
   todo: TodoItem & { id?: string };
   onClose: () => void;
   onUpdate?: (updatedFields: Partial<TodoItem>) => Promise<void>;
+  availableCategories?: string[];
 }
 
 type ViewTab = 'essentials' | 'remarks' | 'checklist';
 
-export default function ViewTodoItem({ todo, onClose, onUpdate }: ViewTodoItemProps) {
+export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategories = [] }: ViewTodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [checklistUpdating, setChecklistUpdating] = useState(false);
@@ -36,6 +37,8 @@ export default function ViewTodoItem({ todo, onClose, onUpdate }: ViewTodoItemPr
   const [remarks, setRemarks] = useState(todo.remarks?.content || '');
   const [checklist, setChecklist] = useState<string[]>(todo.checklist || []);
   const [newChecklistItem, setNewChecklistItem] = useState('');
+  const [categories, setCategories] = useState<string[]>(todo.categories || []);
+  const [newCategory, setNewCategory] = useState('');
 
   const getQuadrantLabel = (u: boolean, i: boolean) => {
     if (u && i) return '🔴 Do First (Urgent & Important)';
@@ -77,6 +80,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate }: ViewTodoItemPr
         etaDateTime: etaDateTime ? new Date(etaDateTime).toISOString() : undefined,
         remarks: remarks.trim() ? { type: 'text' as const, content: remarks.trim() } : null,
         checklist: checklist.length > 0 ? checklist : [],
+        categories: categories.length > 0 ? categories : [],
       };
       await onUpdate?.(updatedFields);
       onClose();
@@ -97,6 +101,8 @@ export default function ViewTodoItem({ todo, onClose, onUpdate }: ViewTodoItemPr
     setRemarks(todo.remarks?.content || '');
     setChecklist(todo.checklist || []);
     setNewChecklistItem('');
+    setCategories(todo.categories || []);
+    setNewCategory('');
     setError(null);
     setEditing(false);
   };
@@ -170,6 +176,71 @@ export default function ViewTodoItem({ todo, onClose, onUpdate }: ViewTodoItemPr
                   <input type="datetime-local" id="edit-eta" value={etaDateTime}
                     onChange={(e) => setEtaDateTime(e.target.value)}
                     disabled={isSubmitting} className={styles.input} />
+                </div>
+
+                <div className={styles.categorySection}>
+                  <label className={styles.label}>Categories</label>
+                  {(availableCategories.length > 0 || categories.length > 0) && (
+                    <div className={styles.categoryChips}>
+                      {availableCategories.filter(c => !categories.includes(c)).map(cat => (
+                        <button
+                          key={cat}
+                          type="button"
+                          className={styles.categoryChip}
+                          disabled={isSubmitting}
+                          onClick={() => setCategories(prev => [...prev, cat])}
+                        >
+                          {cat}
+                        </button>
+                      ))}
+                      {categories.map(cat => (
+                        <button
+                          key={cat}
+                          type="button"
+                          className={`${styles.categoryChip} ${styles.categoryChipSelected}`}
+                          disabled={isSubmitting}
+                          onClick={() => setCategories(prev => prev.filter(c => c !== cat))}
+                        >
+                          {cat}
+                          <span className={styles.categoryChipRemove}>✕</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <div className={styles.categoryAdd}>
+                    <input
+                      type="text"
+                      value={newCategory}
+                      onChange={(e) => setNewCategory(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && newCategory.trim()) {
+                          e.preventDefault();
+                          const cat = newCategory.trim();
+                          if (!categories.includes(cat)) {
+                            setCategories(prev => [...prev, cat]);
+                          }
+                          setNewCategory('');
+                        }
+                      }}
+                      placeholder="Add new category..."
+                      className={styles.input}
+                      disabled={isSubmitting}
+                    />
+                    <button
+                      type="button"
+                      className={`${styles.button} ${styles.buttonSecondary} ${styles.categoryAddBtn}`}
+                      disabled={isSubmitting || !newCategory.trim()}
+                      onClick={() => {
+                        const cat = newCategory.trim();
+                        if (cat && !categories.includes(cat)) {
+                          setCategories(prev => [...prev, cat]);
+                        }
+                        setNewCategory('');
+                      }}
+                    >
+                      Add
+                    </button>
+                  </div>
                 </div>
 
                 <div className={styles.preview}>

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -348,7 +348,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                   <span className={styles.label}>Tags</span>
                   <div className={styles.categoryChips}>
                     {todo.categories.map((cat) => (
-                      <span key={cat} className={`${styles.categoryChip} ${styles.categoryChipSelected}`}>
+                      <span key={cat} className={`${styles.categoryChip} ${styles.categoryChipStatic}`}>
                         {cat}
                       </span>
                     ))}


### PR DESCRIPTION
## Summary

Implements [#21](https://github.com/xiaomi7732/ArrangeV4/issues/21) — full tag (category) support.

### Features

- **Tag picker** — new "Tags" tab in Add/Edit TODO dialogs for selecting existing tags or creating new ones
- **Tag filter** — always-visible, collapsible tag bar above the matrix with toggleable chips + "Untagged" filter
- **Manage Tags dialog** — accessible via ⚙ button in the header:
  - **Rename** — inline edit with case-insensitive duplicate detection
  - **Delete** — confirmation prompt, removes tag from all items
  - **Merge** — move all items from one tag into another (deduplicates)

### Technical details

- Tags map to the Outlook Graph API `categories` field (already supported by the data layer)
- All bulk operations use optimistic UI with full rollback on failure (including filter state)
- Parallel Graph API calls with concurrency limit of 5
- Extracted reusable `TagPicker` component (shared by Add and View)
- Extracted `bulkUpdateCategories` helper (shared by delete/rename/merge)

### Files changed

| File | Change |
|---|---|
| `components/TagPicker.tsx` | **New** — reusable tag picker component |
| `components/ManageTags.tsx` | **New** — manage tags dialog (rename/delete/merge) |
| `components/ManageTags.module.css` | **New** — styles for manage tags dialog |
| `components/AddTodoItem.tsx` | Tags tab + `availableCategories` prop |
| `components/ViewTodoItem.tsx` | Tags tab in edit + read modes |
| `components/AddTodoItem.module.css` | Tag chip styles |
| `app/matrix/page.tsx` | Tag filter, manage tags handlers, bulk update helper |
| `app/matrix/page.module.css` | Tag bar + filter chip styles |
