### PR TITLE
feat: checklist bulk-add, drag-and-drop reorder (#34, #35)

### DIFF
--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -127,7 +127,7 @@
 .checklistEditItem {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 8px;
   padding: 6px 10px;
   border: 1px solid #e5e7eb;
   border-radius: 6px;
@@ -171,11 +171,56 @@
   align-items: center;
   gap: 8px;
   cursor: pointer;
+  flex: 1;
+  min-width: 0;
 }
 
 .checklistCheckedText {
   text-decoration: line-through;
   color: #9ca3af;
+}
+
+.checklistItemText {
+  flex: 1;
+  min-width: 0;
+}
+
+.checklistDragHandle {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  cursor: grab;
+  font-size: 1rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+  transition: color 0.15s;
+  line-height: 1;
+  touch-action: none;
+  flex-shrink: 0;
+}
+
+.checklistDragHandle:hover {
+  color: #6b7280;
+}
+
+.checklistDragHandle:active {
+  cursor: grabbing;
+}
+
+.checklistBulkAdd {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.checklistBulkAdd .textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.checklistBulkActions {
+  display: flex;
+  gap: 8px;
 }
 
 .input,

--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -199,12 +199,18 @@
   flex-shrink: 0;
 }
 
-.checklistDragHandle:hover {
+.checklistDragHandle:not(:disabled):hover {
   color: #6b7280;
 }
 
-.checklistDragHandle:active {
+.checklistDragHandle:not(:disabled):active {
   cursor: grabbing;
+}
+
+.checklistDragHandle:disabled {
+  color: #d1d5db;
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .checklistBulkAdd {

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { TodoItem, TodoStatus } from '@/lib/todoDataService';
+import ChecklistEditor from './ChecklistEditor';
 import TagPicker from './TagPicker';
 import styles from './AddTodoItem.module.css';
 
@@ -39,7 +40,6 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
   const [status, setStatus] = useState<TodoStatus>('new');
   const [remarks, setRemarks] = useState('');
   const [checklist, setChecklist] = useState<string[]>([]);
-  const [newChecklistItem, setNewChecklistItem] = useState('');
   const [etaDateTime, setEtaDateTime] = useState(() => getDateTimeString(24)); // 24 hours from now
   const [etsDateTime, setEtsDateTime] = useState(() => getDateTimeString());
   const [categories, setCategories] = useState<string[]>([]);
@@ -53,7 +53,6 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
     setStatus('new');
     setRemarks('');
     setChecklist([]);
-    setNewChecklistItem('');
     setEtaDateTime(getDateTimeString(24)); // 24 hours from now
     setEtsDateTime(getDateTimeString());
     setCategories([]);
@@ -245,43 +244,13 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
             <div className={styles.tabContent}>
               <div className={styles.formGroup}>
                 <label className={styles.label}>Checklist</label>
-                {checklist.length > 0 && (
-                  <ul className={styles.checklistEdit}>
-                    {checklist.map((item, idx) => (
-                      <li key={idx} className={styles.checklistEditItem}>
-                        <span>{item.replace(/^-\[x?\]\s*/, '')}</span>
-                        <button type="button" className={styles.checklistRemove}
-                          disabled={isSubmitting}
-                          onClick={() => setChecklist(prev => prev.filter((_, i) => i !== idx))}>
-                          ✕
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-                <div className={styles.checklistAdd}>
-                  <input type="text" value={newChecklistItem}
-                    onChange={(e) => setNewChecklistItem(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && newChecklistItem.trim()) {
-                        e.preventDefault();
-                        setChecklist(prev => [...prev, '-[] ' + newChecklistItem.trim()]);
-                        setNewChecklistItem('');
-                      }
-                    }}
-                    placeholder="Add checklist item..."
-                    className={styles.input} disabled={isSubmitting} />
-                  <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
-                    disabled={isSubmitting || !newChecklistItem.trim()}
-                    onClick={() => {
-                      if (newChecklistItem.trim()) {
-                        setChecklist(prev => [...prev, '-[] ' + newChecklistItem.trim()]);
-                        setNewChecklistItem('');
-                      }
-                    }}>
-                    Add
-                  </button>
-                </div>
+                <ChecklistEditor
+                  items={checklist}
+                  onChange={setChecklist}
+                  disabled={isSubmitting}
+                  showRemoveButton
+                  showAddInput
+                />
               </div>
             </div>
           )}

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -98,18 +98,17 @@ export default function ChecklistEditor({
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
-      setItemIds(ids => {
-        const oldIndex = ids.indexOf(String(active.id));
-        const newIndex = ids.indexOf(String(over.id));
-        if (oldIndex >= 0 && newIndex >= 0) {
-          prevItemsRef.current = arrayMove(items, oldIndex, newIndex);
-          onChange(prevItemsRef.current);
-          return arrayMove(ids, oldIndex, newIndex);
-        }
-        return ids;
-      });
+      const oldIndex = renderIds.indexOf(String(active.id));
+      const newIndex = renderIds.indexOf(String(over.id));
+      if (oldIndex >= 0 && newIndex >= 0) {
+        const updatedItems = arrayMove(items, oldIndex, newIndex);
+        const updatedIds = arrayMove(renderIds, oldIndex, newIndex);
+        prevItemsRef.current = updatedItems;
+        setItemIds(updatedIds);
+        onChange(updatedItems);
+      }
     }
-  }, [items, onChange]);
+  }, [items, onChange, renderIds]);
 
   const handleToggle = (idx: number) => {
     const item = items[idx];

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -37,7 +37,9 @@ export default function ChecklistEditor({
     if (over && active.id !== over.id) {
       const oldIndex = items.findIndex((_, i) => `checklist-${i}` === active.id);
       const newIndex = items.findIndex((_, i) => `checklist-${i}` === over.id);
-      onChange(arrayMove(items, oldIndex, newIndex));
+      if (oldIndex >= 0 && newIndex >= 0) {
+        onChange(arrayMove(items, oldIndex, newIndex));
+      }
     }
   };
 
@@ -123,6 +125,7 @@ export default function ChecklistEditor({
                   Add All
                 </button>
                 <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
+                  disabled={disabled}
                   onClick={() => { setBulkAddMode(false); setBulkAddText(''); }}>
                   Single Mode
                 </button>

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState } from 'react';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import SortableChecklistItem from './SortableChecklistItem';
+import styles from './AddTodoItem.module.css';
+
+interface ChecklistEditorProps {
+  items: string[];
+  onChange: (items: string[]) => void;
+  disabled?: boolean;
+  showCheckboxes?: boolean;
+  showRemoveButton?: boolean;
+  showAddInput?: boolean;
+}
+
+export default function ChecklistEditor({
+  items,
+  onChange,
+  disabled = false,
+  showCheckboxes = false,
+  showRemoveButton = false,
+  showAddInput = false,
+}: ChecklistEditorProps) {
+  const [newChecklistItem, setNewChecklistItem] = useState('');
+  const [bulkAddMode, setBulkAddMode] = useState(false);
+  const [bulkAddText, setBulkAddText] = useState('');
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = items.findIndex((_, i) => `checklist-${i}` === active.id);
+      const newIndex = items.findIndex((_, i) => `checklist-${i}` === over.id);
+      onChange(arrayMove(items, oldIndex, newIndex));
+    }
+  };
+
+  const handleToggle = (idx: number) => {
+    const item = items[idx];
+    const checked = item.startsWith('-[x]');
+    const text = item.replace(/^-\[x?\]\s*/, '');
+    const updated = [...items];
+    updated[idx] = checked ? '-[] ' + text : '-[x] ' + text;
+    onChange(updated);
+  };
+
+  const handleRemove = (idx: number) => {
+    onChange(items.filter((_, i) => i !== idx));
+  };
+
+  const handleAddSingle = (text: string) => {
+    onChange([...items, '-[] ' + text]);
+  };
+
+  const handleAddBulk = (text: string) => {
+    const newItems = text.split('\n').map(l => l.trim()).filter(Boolean).map(l => '-[] ' + l);
+    if (newItems.length > 0) {
+      onChange([...items, ...newItems]);
+    }
+  };
+
+  return (
+    <>
+      {items.length > 0 && (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={items.map((_, i) => `checklist-${i}`)} strategy={verticalListSortingStrategy}>
+            <ul className={styles.checklistEdit}>
+              {items.map((item, idx) => {
+                const checked = item.startsWith('-[x]');
+                const text = item.replace(/^-\[x?\]\s*/, '');
+                return (
+                  <SortableChecklistItem key={`checklist-${idx}`} id={`checklist-${idx}`} disabled={disabled}>
+                    {showCheckboxes ? (
+                      <label className={styles.checklistCheckLabel}>
+                        <input type="checkbox" checked={checked} disabled={disabled}
+                          className={styles.checkbox}
+                          onChange={() => handleToggle(idx)} />
+                        <span className={checked ? styles.checklistCheckedText : undefined}>{text}</span>
+                      </label>
+                    ) : (
+                      <span className={styles.checklistItemText}>{text}</span>
+                    )}
+                    {showRemoveButton && (
+                      <button type="button" className={styles.checklistRemove}
+                        disabled={disabled}
+                        onClick={() => handleRemove(idx)}>
+                        ✕
+                      </button>
+                    )}
+                  </SortableChecklistItem>
+                );
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      {showAddInput && (
+        <>
+          {bulkAddMode ? (
+            <div className={styles.checklistBulkAdd}>
+              <textarea
+                value={bulkAddText}
+                onChange={(e) => setBulkAddText(e.target.value)}
+                placeholder="Enter one item per line..."
+                className={styles.textarea}
+                disabled={disabled}
+                rows={4}
+              />
+              <div className={styles.checklistBulkActions}>
+                <button type="button" className={`${styles.button} ${styles.buttonPrimary} ${styles.checklistAddBtn}`}
+                  disabled={disabled || !bulkAddText.trim()}
+                  onClick={() => {
+                    handleAddBulk(bulkAddText);
+                    setBulkAddText('');
+                  }}>
+                  Add All
+                </button>
+                <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
+                  onClick={() => { setBulkAddMode(false); setBulkAddText(''); }}>
+                  Single Mode
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className={styles.checklistAdd}>
+              <input type="text" value={newChecklistItem}
+                onChange={(e) => setNewChecklistItem(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && newChecklistItem.trim()) {
+                    e.preventDefault();
+                    handleAddSingle(newChecklistItem.trim());
+                    setNewChecklistItem('');
+                  }
+                }}
+                placeholder="Add checklist item..."
+                className={styles.input} disabled={disabled} />
+              <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
+                disabled={disabled || !newChecklistItem.trim()}
+                onClick={() => {
+                  if (newChecklistItem.trim()) {
+                    handleAddSingle(newChecklistItem.trim());
+                    setNewChecklistItem('');
+                  }
+                }}>
+                Add
+              </button>
+              <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
+                disabled={disabled}
+                onClick={() => setBulkAddMode(true)}
+                title="Add multiple items at once">
+                Bulk
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import SortableChecklistItem from './SortableChecklistItem';
@@ -15,6 +15,10 @@ interface ChecklistEditorProps {
   showAddInput?: boolean;
 }
 
+function generateIds(count: number, startFrom: number): string[] {
+  return Array.from({ length: count }, (_, i) => `cl-${startFrom + i}`);
+}
+
 export default function ChecklistEditor({
   items,
   onChange,
@@ -27,21 +31,38 @@ export default function ChecklistEditor({
   const [bulkAddMode, setBulkAddMode] = useState(false);
   const [bulkAddText, setBulkAddText] = useState('');
 
+  // Stable IDs for sortable items — tracked via ref so they persist across renders
+  const nextIdCounter = useRef(items.length);
+  const stableIds = useRef<string[]>(generateIds(items.length, 0));
+
+  // Sync stable IDs when items length changes from external updates
+  if (stableIds.current.length !== items.length) {
+    if (items.length > stableIds.current.length) {
+      const newIds = generateIds(items.length - stableIds.current.length, nextIdCounter.current);
+      nextIdCounter.current += newIds.length;
+      stableIds.current = [...stableIds.current, ...newIds];
+    } else {
+      stableIds.current = stableIds.current.slice(0, items.length);
+    }
+  }
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  const handleDragEnd = (event: DragEndEvent) => {
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
-      const oldIndex = items.findIndex((_, i) => `checklist-${i}` === active.id);
-      const newIndex = items.findIndex((_, i) => `checklist-${i}` === over.id);
+      const ids = stableIds.current;
+      const oldIndex = ids.indexOf(String(active.id));
+      const newIndex = ids.indexOf(String(over.id));
       if (oldIndex >= 0 && newIndex >= 0) {
+        stableIds.current = arrayMove(ids, oldIndex, newIndex);
         onChange(arrayMove(items, oldIndex, newIndex));
       }
     }
-  };
+  }, [items, onChange]);
 
   const handleToggle = (idx: number) => {
     const item = items[idx];
@@ -53,16 +74,21 @@ export default function ChecklistEditor({
   };
 
   const handleRemove = (idx: number) => {
+    stableIds.current = stableIds.current.filter((_, i) => i !== idx);
     onChange(items.filter((_, i) => i !== idx));
   };
 
   const handleAddSingle = (text: string) => {
+    stableIds.current = [...stableIds.current, `cl-${nextIdCounter.current++}`];
     onChange([...items, '-[] ' + text]);
   };
 
   const handleAddBulk = (text: string) => {
     const newItems = text.split('\n').map(l => l.trim()).filter(Boolean).map(l => '-[] ' + l);
     if (newItems.length > 0) {
+      const newIds = generateIds(newItems.length, nextIdCounter.current);
+      nextIdCounter.current += newIds.length;
+      stableIds.current = [...stableIds.current, ...newIds];
       onChange([...items, ...newItems]);
     }
   };
@@ -71,13 +97,14 @@ export default function ChecklistEditor({
     <>
       {items.length > 0 && (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={items.map((_, i) => `checklist-${i}`)} strategy={verticalListSortingStrategy}>
+          <SortableContext items={stableIds.current} strategy={verticalListSortingStrategy}>
             <ul className={styles.checklistEdit}>
               {items.map((item, idx) => {
                 const checked = item.startsWith('-[x]');
                 const text = item.replace(/^-\[x?\]\s*/, '');
+                const itemId = stableIds.current[idx];
                 return (
-                  <SortableChecklistItem key={`checklist-${idx}`} id={`checklist-${idx}`} disabled={disabled}>
+                  <SortableChecklistItem key={itemId} id={itemId} disabled={disabled}>
                     {showCheckboxes ? (
                       <label className={styles.checklistCheckLabel}>
                         <input type="checkbox" checked={checked} disabled={disabled}

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import SortableChecklistItem from './SortableChecklistItem';
@@ -19,6 +19,38 @@ function generateIds(count: number, startFrom: number): string[] {
   return Array.from({ length: count }, (_, i) => `cl-${startFrom + i}`);
 }
 
+function reconcileIds(
+  newItems: string[],
+  oldItems: string[],
+  oldIds: string[],
+  counter: { current: number },
+): string[] {
+  if (newItems.length === oldIds.length && newItems === oldItems) {
+    return oldIds;
+  }
+  if (newItems.length === oldIds.length) {
+    // Same length — reconcile by matching content
+    const usedIndices = new Set<number>();
+    const result: string[] = [];
+    for (const item of newItems) {
+      const matchIdx = oldItems.findIndex((old, i) => old === item && !usedIndices.has(i));
+      if (matchIdx >= 0) {
+        usedIndices.add(matchIdx);
+        result.push(oldIds[matchIdx]);
+      } else {
+        result.push(`cl-${counter.current++}`);
+      }
+    }
+    return result;
+  }
+  if (newItems.length > oldIds.length) {
+    const added = generateIds(newItems.length - oldIds.length, counter.current);
+    counter.current += added.length;
+    return [...oldIds, ...added];
+  }
+  return oldIds.slice(0, newItems.length);
+}
+
 export default function ChecklistEditor({
   items,
   onChange,
@@ -31,38 +63,18 @@ export default function ChecklistEditor({
   const [bulkAddMode, setBulkAddMode] = useState(false);
   const [bulkAddText, setBulkAddText] = useState('');
 
-  // Stable IDs for sortable items — tracked via ref so they persist across renders
+  // Stable IDs for sortable items
   const nextIdCounter = useRef(items.length);
-  const stableIds = useRef<string[]>(generateIds(items.length, 0));
-  const prevItems = useRef<string[]>(items);
+  const [itemIds, setItemIds] = useState<string[]>(() => generateIds(items.length, 0));
+  const prevItemsRef = useRef<string[]>(items);
 
-  // Reconcile stable IDs when items change externally (reorder, rollback, add, remove)
-  if (prevItems.current !== items) {
-    if (items.length === stableIds.current.length) {
-      // Same length but possibly reordered — reconcile by matching content
-      const oldItems = prevItems.current;
-      const oldIds = stableIds.current;
-      const usedIndices = new Set<number>();
-      const newIds: string[] = [];
-      for (const item of items) {
-        const matchIdx = oldItems.findIndex((old, i) => old === item && !usedIndices.has(i));
-        if (matchIdx >= 0) {
-          usedIndices.add(matchIdx);
-          newIds.push(oldIds[matchIdx]);
-        } else {
-          newIds.push(`cl-${nextIdCounter.current++}`);
-        }
-      }
-      stableIds.current = newIds;
-    } else if (items.length > stableIds.current.length) {
-      const added = generateIds(items.length - stableIds.current.length, nextIdCounter.current);
-      nextIdCounter.current += added.length;
-      stableIds.current = [...stableIds.current, ...added];
-    } else {
-      stableIds.current = stableIds.current.slice(0, items.length);
+  // Reconcile IDs on commit when items change externally
+  useEffect(() => {
+    if (prevItemsRef.current !== items) {
+      setItemIds(prev => reconcileIds(items, prevItemsRef.current, prev, nextIdCounter));
+      prevItemsRef.current = items;
     }
-    prevItems.current = items;
-  }
+  }, [items]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -72,13 +84,16 @@ export default function ChecklistEditor({
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
-      const ids = stableIds.current;
-      const oldIndex = ids.indexOf(String(active.id));
-      const newIndex = ids.indexOf(String(over.id));
-      if (oldIndex >= 0 && newIndex >= 0) {
-        stableIds.current = arrayMove(ids, oldIndex, newIndex);
-        onChange(arrayMove(items, oldIndex, newIndex));
-      }
+      setItemIds(ids => {
+        const oldIndex = ids.indexOf(String(active.id));
+        const newIndex = ids.indexOf(String(over.id));
+        if (oldIndex >= 0 && newIndex >= 0) {
+          prevItemsRef.current = arrayMove(items, oldIndex, newIndex);
+          onChange(prevItemsRef.current);
+          return arrayMove(ids, oldIndex, newIndex);
+        }
+        return ids;
+      });
     }
   }, [items, onChange]);
 
@@ -88,17 +103,23 @@ export default function ChecklistEditor({
     const text = item.replace(/^-\[x?\]\s*/, '');
     const updated = [...items];
     updated[idx] = checked ? '-[] ' + text : '-[x] ' + text;
+    prevItemsRef.current = updated;
     onChange(updated);
   };
 
   const handleRemove = (idx: number) => {
-    stableIds.current = stableIds.current.filter((_, i) => i !== idx);
-    onChange(items.filter((_, i) => i !== idx));
+    setItemIds(ids => ids.filter((_, i) => i !== idx));
+    const updated = items.filter((_, i) => i !== idx);
+    prevItemsRef.current = updated;
+    onChange(updated);
   };
 
   const handleAddSingle = (text: string) => {
-    stableIds.current = [...stableIds.current, `cl-${nextIdCounter.current++}`];
-    onChange([...items, '-[] ' + text]);
+    const newId = `cl-${nextIdCounter.current++}`;
+    setItemIds(ids => [...ids, newId]);
+    const updated = [...items, '-[] ' + text];
+    prevItemsRef.current = updated;
+    onChange(updated);
   };
 
   const handleAddBulk = (text: string) => {
@@ -106,8 +127,10 @@ export default function ChecklistEditor({
     if (newItems.length > 0) {
       const newIds = generateIds(newItems.length, nextIdCounter.current);
       nextIdCounter.current += newIds.length;
-      stableIds.current = [...stableIds.current, ...newIds];
-      onChange([...items, ...newItems]);
+      setItemIds(ids => [...ids, ...newIds]);
+      const updated = [...items, ...newItems];
+      prevItemsRef.current = updated;
+      onChange(updated);
     }
   };
 
@@ -115,14 +138,14 @@ export default function ChecklistEditor({
     <>
       {items.length > 0 && (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={stableIds.current} strategy={verticalListSortingStrategy}>
+          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
             <ul className={styles.checklistEdit}>
               {items.map((item, idx) => {
                 const checked = item.startsWith('-[x]');
                 const text = item.replace(/^-\[x?\]\s*/, '');
-                const itemId = stableIds.current[idx];
+                const id = itemIds[idx];
                 return (
-                  <SortableChecklistItem key={itemId} id={itemId} disabled={disabled}>
+                  <SortableChecklistItem key={id} id={id} disabled={disabled}>
                     {showCheckboxes ? (
                       <label className={styles.checklistCheckLabel}>
                         <input type="checkbox" checked={checked} disabled={disabled}

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -34,16 +34,34 @@ export default function ChecklistEditor({
   // Stable IDs for sortable items — tracked via ref so they persist across renders
   const nextIdCounter = useRef(items.length);
   const stableIds = useRef<string[]>(generateIds(items.length, 0));
+  const prevItems = useRef<string[]>(items);
 
-  // Sync stable IDs when items length changes from external updates
-  if (stableIds.current.length !== items.length) {
-    if (items.length > stableIds.current.length) {
-      const newIds = generateIds(items.length - stableIds.current.length, nextIdCounter.current);
-      nextIdCounter.current += newIds.length;
-      stableIds.current = [...stableIds.current, ...newIds];
+  // Reconcile stable IDs when items change externally (reorder, rollback, add, remove)
+  if (prevItems.current !== items) {
+    if (items.length === stableIds.current.length) {
+      // Same length but possibly reordered — reconcile by matching content
+      const oldItems = prevItems.current;
+      const oldIds = stableIds.current;
+      const usedIndices = new Set<number>();
+      const newIds: string[] = [];
+      for (const item of items) {
+        const matchIdx = oldItems.findIndex((old, i) => old === item && !usedIndices.has(i));
+        if (matchIdx >= 0) {
+          usedIndices.add(matchIdx);
+          newIds.push(oldIds[matchIdx]);
+        } else {
+          newIds.push(`cl-${nextIdCounter.current++}`);
+        }
+      }
+      stableIds.current = newIds;
+    } else if (items.length > stableIds.current.length) {
+      const added = generateIds(items.length - stableIds.current.length, nextIdCounter.current);
+      nextIdCounter.current += added.length;
+      stableIds.current = [...stableIds.current, ...added];
     } else {
       stableIds.current = stableIds.current.slice(0, items.length);
     }
+    prevItems.current = items;
   }
 
   const sensors = useSensors(

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -158,7 +158,7 @@ export default function ChecklistEditor({
                 const text = item.replace(/^-\[x?\]\s*/, '');
                 const id = renderIds[idx];
                 return (
-                  <SortableChecklistItem key={id} id={id} disabled={disabled}>
+                  <SortableChecklistItem key={id} id={id} disabled={disabled} itemLabel={text}>
                     {showCheckboxes ? (
                       <label className={styles.checklistCheckLabel}>
                         <input type="checkbox" checked={checked} disabled={disabled}

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -192,6 +192,7 @@ export default function ChecklistEditor({
                 value={bulkAddText}
                 onChange={(e) => setBulkAddText(e.target.value)}
                 placeholder="Enter one item per line..."
+                aria-label="Bulk add checklist items"
                 className={styles.textarea}
                 disabled={disabled}
                 rows={4}
@@ -224,6 +225,7 @@ export default function ChecklistEditor({
                   }
                 }}
                 placeholder="Add checklist item..."
+                aria-label="Add checklist item"
                 className={styles.input} disabled={disabled} />
               <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
                 disabled={disabled || !newChecklistItem.trim()}

--- a/src/arrange-v4/components/ChecklistEditor.tsx
+++ b/src/arrange-v4/components/ChecklistEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import SortableChecklistItem from './SortableChecklistItem';
@@ -76,6 +76,20 @@ export default function ChecklistEditor({
     }
   }, [items]);
 
+  // Derive render-safe IDs that are always in sync with items.length
+  const renderIds = useMemo(() => {
+    if (itemIds.length === items.length) return itemIds;
+    // Temporarily pad or trim to match items during the render before useEffect fires
+    if (items.length > itemIds.length) {
+      const padded = [...itemIds];
+      for (let i = itemIds.length; i < items.length; i++) {
+        padded.push(`cl-tmp-${i}`);
+      }
+      return padded;
+    }
+    return itemIds.slice(0, items.length);
+  }, [itemIds, items.length]);
+
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -138,12 +152,12 @@ export default function ChecklistEditor({
     <>
       {items.length > 0 && (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+          <SortableContext items={renderIds} strategy={verticalListSortingStrategy}>
             <ul className={styles.checklistEdit}>
               {items.map((item, idx) => {
                 const checked = item.startsWith('-[x]');
                 const text = item.replace(/^-\[x?\]\s*/, '');
-                const id = itemIds[idx];
+                const id = renderIds[idx];
                 return (
                   <SortableChecklistItem key={id} id={id} disabled={disabled}>
                     {showCheckboxes ? (

--- a/src/arrange-v4/components/SortableChecklistItem.tsx
+++ b/src/arrange-v4/components/SortableChecklistItem.tsx
@@ -33,7 +33,8 @@ export default function SortableChecklistItem({ id, children, disabled }: Sortab
         className={styles.checklistDragHandle}
         {...attributes}
         {...listeners}
-        tabIndex={-1}
+        disabled={disabled}
+        aria-disabled={disabled}
         aria-label="Drag to reorder"
       >
         ⠿

--- a/src/arrange-v4/components/SortableChecklistItem.tsx
+++ b/src/arrange-v4/components/SortableChecklistItem.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import styles from './AddTodoItem.module.css';
 
 interface SortableChecklistItemProps {
   id: string;
-  children: React.ReactNode;
+  children: ReactNode;
   disabled?: boolean;
 }
 

--- a/src/arrange-v4/components/SortableChecklistItem.tsx
+++ b/src/arrange-v4/components/SortableChecklistItem.tsx
@@ -9,9 +9,10 @@ interface SortableChecklistItemProps {
   id: string;
   children: ReactNode;
   disabled?: boolean;
+  itemLabel?: string;
 }
 
-export default function SortableChecklistItem({ id, children, disabled }: SortableChecklistItemProps) {
+export default function SortableChecklistItem({ id, children, disabled, itemLabel }: SortableChecklistItemProps) {
   const {
     attributes,
     listeners,
@@ -36,7 +37,7 @@ export default function SortableChecklistItem({ id, children, disabled }: Sortab
         {...listeners}
         disabled={disabled}
         aria-disabled={disabled}
-        aria-label="Drag to reorder"
+        aria-label={itemLabel ? `Drag to reorder: ${itemLabel}` : 'Drag to reorder'}
       >
         ⠿
       </button>

--- a/src/arrange-v4/components/SortableChecklistItem.tsx
+++ b/src/arrange-v4/components/SortableChecklistItem.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import styles from './AddTodoItem.module.css';
+
+interface SortableChecklistItemProps {
+  id: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+export default function SortableChecklistItem({ id, children, disabled }: SortableChecklistItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <li ref={setNodeRef} style={style} className={styles.checklistEditItem}>
+      <button
+        type="button"
+        className={styles.checklistDragHandle}
+        {...attributes}
+        {...listeners}
+        tabIndex={-1}
+        aria-label="Drag to reorder"
+      >
+        ⠿
+      </button>
+      {children}
+    </li>
+  );
+}

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -21,6 +21,9 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
   const [checklistUpdating, setChecklistUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<ViewTab>('essentials');
+  // Optimistic local state for view-mode checklist (tracks pending changes before server confirms)
+  const [viewChecklist, setViewChecklist] = useState<string[] | null>(null);
+  const displayChecklist = viewChecklist ?? todo.checklist;
 
   const formatLocalDateTime = (isoString?: string) => {
     if (!isoString) return '';
@@ -334,16 +337,18 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
 
           {activeTab === 'checklist' && (
             <div className={styles.tabContent}>
-              {todo.checklist && todo.checklist.length > 0 ? (
+              {displayChecklist && displayChecklist.length > 0 ? (
                 <div className={styles.formGroup}>
                   <span className={styles.label}>Checklist</span>
                   <ChecklistEditor
-                    items={todo.checklist}
+                    items={displayChecklist}
                     onChange={async (updated) => {
+                      setViewChecklist(updated);
                       setChecklistUpdating(true);
                       try {
                         await onUpdate?.({ checklist: updated });
                       } catch (err: unknown) {
+                        setViewChecklist(null);
                         const message = err instanceof Error ? err.message : 'Failed to update checklist';
                         setError(message);
                       } finally {

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -354,6 +354,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
                     onChange={async (updated) => {
                       setViewChecklist(updated);
                       setChecklistUpdating(true);
+                      setError(null);
                       try {
                         await onUpdate?.({ checklist: updated });
                       } catch (err: unknown) {

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -377,7 +377,9 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
 
           <div className={styles.actions}>
             {onUpdate && (
-              <button type="button" onClick={() => { setChecklist(displayChecklist || []); setEditing(true); }}
+              <button type="button"
+                onClick={() => { setChecklist(displayChecklist || []); setEditing(true); }}
+                disabled={checklistUpdating}
                 className={`${styles.button} ${styles.buttonPrimary}`}>
                 Edit
               </button>

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { TodoItem, TodoStatus, STATUS_LABELS } from '@/lib/todoDataService';
+import ChecklistEditor from './ChecklistEditor';
 import TagPicker from './TagPicker';
 import styles from './AddTodoItem.module.css';
 
@@ -37,7 +38,6 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
   const [etaDateTime, setEtaDateTime] = useState(formatLocalDateTime(todo.etaDateTime));
   const [remarks, setRemarks] = useState(todo.remarks?.content || '');
   const [checklist, setChecklist] = useState<string[]>(todo.checklist || []);
-  const [newChecklistItem, setNewChecklistItem] = useState('');
   const [categories, setCategories] = useState<string[]>(todo.categories || []);
 
   const getQuadrantLabel = (u: boolean, i: boolean) => {
@@ -100,7 +100,6 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
     setEtaDateTime(formatLocalDateTime(todo.etaDateTime));
     setRemarks(todo.remarks?.content || '');
     setChecklist(todo.checklist || []);
-    setNewChecklistItem('');
     setCategories(todo.categories || []);
     setError(null);
     setEditing(false);
@@ -215,54 +214,14 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
               <div className={styles.tabContent}>
                 <div className={styles.formGroup}>
                   <label className={styles.label}>Checklist</label>
-                  {checklist.length > 0 && (
-                    <ul className={styles.checklistEdit}>
-                      {checklist.map((item, idx) => {
-                        const checked = item.startsWith('-[x]');
-                        const text = item.replace(/^-\[x?\]\s*/, '');
-                        return (
-                          <li key={idx} className={styles.checklistEditItem}>
-                            <label className={styles.checklistCheckLabel}>
-                              <input type="checkbox" checked={checked} disabled={isSubmitting}
-                                className={styles.checkbox}
-                                onChange={() => setChecklist(prev => prev.map((it, i) =>
-                                  i === idx ? (checked ? '-[] ' + text : '-[x] ' + text) : it
-                                ))} />
-                              <span className={checked ? styles.checklistCheckedText : undefined}>{text}</span>
-                            </label>
-                            <button type="button" className={styles.checklistRemove}
-                              disabled={isSubmitting}
-                              onClick={() => setChecklist(prev => prev.filter((_, i) => i !== idx))}>
-                              ✕
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                  <div className={styles.checklistAdd}>
-                    <input type="text" value={newChecklistItem}
-                      onChange={(e) => setNewChecklistItem(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && newChecklistItem.trim()) {
-                          e.preventDefault();
-                          setChecklist(prev => [...prev, '-[] ' + newChecklistItem.trim()]);
-                          setNewChecklistItem('');
-                        }
-                      }}
-                      placeholder="Add checklist item..."
-                      className={styles.input} disabled={isSubmitting} />
-                    <button type="button" className={`${styles.button} ${styles.buttonSecondary} ${styles.checklistAddBtn}`}
-                      disabled={isSubmitting || !newChecklistItem.trim()}
-                      onClick={() => {
-                        if (newChecklistItem.trim()) {
-                          setChecklist(prev => [...prev, '-[] ' + newChecklistItem.trim()]);
-                          setNewChecklistItem('');
-                        }
-                      }}>
-                      Add
-                    </button>
-                  </div>
+                  <ChecklistEditor
+                    items={checklist}
+                    onChange={setChecklist}
+                    disabled={isSubmitting}
+                    showCheckboxes
+                    showRemoveButton
+                    showAddInput
+                  />
                 </div>
               </div>
             )}
@@ -378,32 +337,22 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
               {todo.checklist && todo.checklist.length > 0 ? (
                 <div className={styles.formGroup}>
                   <span className={styles.label}>Checklist</span>
-                  <ul className={styles.checklistEdit}>
-                    {todo.checklist.map((item, idx) => {
-                      const checked = item.startsWith('-[x]');
-                      const text = item.replace(/^-\[x?\]\s*/, '');
-                      return (
-                        <li key={idx} className={styles.checklistEditItem}>
-                          <label className={styles.checklistCheckLabel}>
-                            <input type="checkbox" checked={checked} className={styles.checkbox}
-                              onChange={async () => {
-                                const updated = [...todo.checklist!];
-                                updated[idx] = checked ? '-[] ' + text : '-[x] ' + text;
-                                setChecklistUpdating(true);
-                                try {
-                                  await onUpdate?.({ checklist: updated });
-                                } catch (err: any) {
-                                  setError(err.message || 'Failed to update checklist');
-                                } finally {
-                                  setChecklistUpdating(false);
-                                }
-                              }} disabled={!onUpdate || checklistUpdating} />
-                            <span className={checked ? styles.checklistCheckedText : undefined}>{text}</span>
-                          </label>
-                        </li>
-                      );
-                    })}
-                  </ul>
+                  <ChecklistEditor
+                    items={todo.checklist}
+                    onChange={async (updated) => {
+                      setChecklistUpdating(true);
+                      try {
+                        await onUpdate?.({ checklist: updated });
+                      } catch (err: unknown) {
+                        const message = err instanceof Error ? err.message : 'Failed to update checklist';
+                        setError(message);
+                      } finally {
+                        setChecklistUpdating(false);
+                      }
+                    }}
+                    disabled={!onUpdate || checklistUpdating}
+                    showCheckboxes
+                  />
                 </div>
               ) : (
                 <p className={styles.tabPlaceholder}>No checklist items</p>

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { TodoItem, TodoStatus, STATUS_LABELS } from '@/lib/todoDataService';
 import ChecklistEditor from './ChecklistEditor';
 import TagPicker from './TagPicker';
@@ -24,6 +24,11 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
   // Optimistic local state for view-mode checklist (tracks pending changes before server confirms)
   const [viewChecklist, setViewChecklist] = useState<string[] | null>(null);
   const displayChecklist = viewChecklist ?? todo.checklist;
+
+  // Reset optimistic state when the todo changes (different item selected)
+  useEffect(() => {
+    setViewChecklist(null);
+  }, [todo.id]);
 
   const formatLocalDateTime = (isoString?: string) => {
     if (!isoString) return '';
@@ -371,7 +376,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
 
           <div className={styles.actions}>
             {onUpdate && (
-              <button type="button" onClick={() => setEditing(true)}
+              <button type="button" onClick={() => { setChecklist(displayChecklist || []); setEditing(true); }}
                 className={`${styles.button} ${styles.buttonPrimary}`}>
                 Edit
               </button>

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -250,6 +250,10 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <h2 className={styles.title}>{todo.subject}</h2>
 
+        {error && (
+          <div className={styles.error} role="alert">{error}</div>
+        )}
+
         <div className={styles.form}>
           <div className={styles.tabBar}>
             <button type="button" className={`${styles.tab} ${activeTab === 'essentials' ? styles.tabActive : ''}`}

--- a/src/arrange-v4/package-lock.json
+++ b/src/arrange-v4/package-lock.json
@@ -367,14 +367,14 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/src/arrange-v4/package-lock.json
+++ b/src/arrange-v4/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@azure/msal-browser": "^4.27.0",
         "@azure/msal-react": "^3.0.23",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "next": "16.1.1",
         "react": "19.2.3",
@@ -29,6 +32,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.27.0.tgz",
       "integrity": "sha512-bZ8Pta6YAbdd0o0PEaL1/geBsPrLEnyY/RDWqvF1PP9RUH8EMLvUMGoZFYS6jSlUan6KZ9IMTLCnwpWWpQRK/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "15.13.3"
       },
@@ -89,6 +93,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -305,6 +310,60 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1348,6 +1407,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1407,6 +1467,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -1906,6 +1967,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2246,6 +2308,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2799,6 +2862,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2984,6 +3048,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4839,6 +4904,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4848,6 +4914,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5515,6 +5582,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5677,6 +5745,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5952,6 +6021,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/arrange-v4/package.json
+++ b/src/arrange-v4/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@azure/msal-browser": "^4.27.0",
     "@azure/msal-react": "^3.0.23",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "next": "16.1.1",
     "react": "19.2.3",


### PR DESCRIPTION
## Summary

Implements two feature requests for the checklist UX:

### Issue #34 — Bulk-Add Checklist Items
- **"Bulk" button** toggles to a `<textarea>` where each line becomes a checklist item
- **"Single Mode"** switches back to one-at-a-time input (better for mobile)

### Issue #35 — Drag-and-Drop Reorder
- Each checklist item has a **⠿ drag handle** for reordering (via `@dnd-kit`)
- Works in **both view mode and edit mode** (view mode persists immediately)
- Supports **mouse and touch** input

### DRY Refactor
Extracted a reusable `ChecklistEditor` component eliminating ~190 lines of duplicated code across `AddTodoItem.tsx` and `ViewTodoItem.tsx`.

### Files Changed
- **New:** `ChecklistEditor.tsx`, `SortableChecklistItem.tsx`
- **Modified:** `AddTodoItem.tsx`, `ViewTodoItem.tsx`, `AddTodoItem.module.css`, `package.json`, `package-lock.json`

Closes #34, Closes #35