### PR TITLE
feat: two-step inline confirmation for Delete Book button (#33)

### DIFF
--- a/src/arrange-v4/components/CalendarList.module.css
+++ b/src/arrange-v4/components/CalendarList.module.css
@@ -165,7 +165,7 @@
   border-radius: 6px;
   border: none;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: color 0.2s, background-color 0.2s;
   font-size: 0.8rem;
 }
 

--- a/src/arrange-v4/components/CalendarList.module.css
+++ b/src/arrange-v4/components/CalendarList.module.css
@@ -158,23 +158,68 @@
 }
 
 .deleteButton {
-  width: 100%;
-  background-color: #fef2f2;
-  color: #991b1b;
-  font-weight: 500;
-  padding: 8px 16px;
-  border-radius: 4px;
+  background: none;
+  color: #9ca3af;
+  font-weight: 400;
+  padding: 4px 8px;
+  border-radius: 6px;
   border: none;
   cursor: pointer;
-  transition: background-color 0.2s;
-  font-size: 0.875rem;
+  transition: all 0.2s;
+  font-size: 0.8rem;
 }
 
 .deleteButton:hover:not(:disabled) {
-  background-color: #fecaca;
+  color: #991b1b;
+  background-color: #fef2f2;
 }
 
 .deleteButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.deleteConfirmRow {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.deleteCancelButton {
+  flex: 1;
+  background-color: #f3f4f6;
+  color: #374151;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  font-size: 0.8rem;
+}
+
+.deleteCancelButton:hover {
+  background-color: #e5e7eb;
+}
+
+.deleteConfirmButton {
+  flex: 1;
+  background-color: #dc2626;
+  color: white;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  font-size: 0.8rem;
+}
+
+.deleteConfirmButton:hover:not(:disabled) {
+  background-color: #b91c1c;
+}
+
+.deleteConfirmButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/src/arrange-v4/components/CalendarList.module.css
+++ b/src/arrange-v4/components/CalendarList.module.css
@@ -202,6 +202,11 @@
   background-color: #e5e7eb;
 }
 
+.deleteCancelButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .deleteConfirmButton {
   flex: 1;
   background-color: #dc2626;

--- a/src/arrange-v4/components/CalendarList.module.css
+++ b/src/arrange-v4/components/CalendarList.module.css
@@ -198,7 +198,7 @@
   font-size: 0.8rem;
 }
 
-.deleteCancelButton:hover {
+.deleteCancelButton:hover:not(:disabled) {
   background-color: #e5e7eb;
 }
 

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -55,16 +55,14 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
       console.error('Failed to delete book:', error);
       alert('Failed to delete book. Please try again.');
     } finally {
+      const calId = calendar.id;
       setDeletingId(null);
-      setConfirmingId(prev => {
-        if (prev === calendar.id) {
-          // Restore focus to delete button if the calendar still exists (e.g., on failure)
-          const btn = deleteButtonRefs.current.get(calendar.id!);
-          if (btn) requestAnimationFrame(() => btn.focus());
-          return null;
-        }
-        return prev;
-      });
+      setConfirmingId(prev => prev === calId ? null : prev);
+      // Restore focus to delete button if the calendar still exists (e.g., on failure)
+      if (calId) {
+        const btn = deleteButtonRefs.current.get(calId);
+        if (btn) requestAnimationFrame(() => btn.focus());
+      }
     }
   }, [onDeleteCalendar]);
   if (loading) {
@@ -156,8 +154,9 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
               </p>
             )}
             <div className={styles.calendarFooter}>
-              {calendar.id && (
-                confirmingId === calendar.id ? (
+              {calendar.id && (() => {
+                const bookName = getCalendarDisplayName(calendar);
+                return confirmingId === calendar.id ? (
                   <div
                     className={styles.deleteConfirmRow}
                     onClick={(e) => e.stopPropagation()}
@@ -171,6 +170,7 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                       }}
                       disabled={!!deletingId}
                       className={styles.deleteCancelButton}
+                      aria-label={`Cancel deleting ${bookName}`}
                     >
                       Cancel
                     </button>
@@ -179,6 +179,7 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                       onClick={() => handleDelete(calendar)}
                       disabled={!!deletingId}
                       className={styles.deleteConfirmButton}
+                      aria-label={`Confirm delete ${bookName}`}
                     >
                       {deletingId === calendar.id ? 'Deleting...' : 'Confirm Delete'}
                     </button>
@@ -192,11 +193,12 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                     onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id ?? null); }}
                     disabled={!!deletingId}
                     className={styles.deleteButton}
+                    aria-label={`Delete ${bookName}`}
                   >
                     🗑 Delete
                   </button>
-                )
-              )}
+                );
+              })()}
             </div>
           </div>
         ))}

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -156,16 +156,19 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
             <div className={styles.calendarFooter}>
               {calendar.id && (() => {
                 const bookName = getCalendarDisplayName(calendar);
-                return confirmingId === calendar.id ? (
+                const bookId = calendar.id;
+                return confirmingId === bookId ? (
                   <div
                     className={styles.deleteConfirmRow}
                     onClick={(e) => e.stopPropagation()}
                     onMouseDown={(e) => e.stopPropagation()}
+                    onMouseMove={() => setConfirmingId(bookId)}
+                    onFocus={() => setConfirmingId(bookId)}
                   >
                     <button
                       onClick={() => {
                         setConfirmingId(null);
-                        const btn = deleteButtonRefs.current.get(calendar.id!);
+                        const btn = deleteButtonRefs.current.get(bookId);
                         if (btn) requestAnimationFrame(() => btn.focus());
                       }}
                       disabled={!!deletingId}
@@ -175,22 +178,22 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                       Cancel
                     </button>
                     <button
-                      ref={confirmingId === calendar.id ? confirmButtonRef : undefined}
+                      ref={confirmingId === bookId ? confirmButtonRef : undefined}
                       onClick={() => handleDelete(calendar)}
                       disabled={!!deletingId}
                       className={styles.deleteConfirmButton}
                       aria-label={`Confirm delete ${bookName}`}
                     >
-                      {deletingId === calendar.id ? 'Deleting...' : 'Confirm Delete'}
+                      {deletingId === bookId ? 'Deleting...' : 'Confirm Delete'}
                     </button>
                   </div>
                 ) : (
                   <button
                     ref={(el) => {
-                      if (el && calendar.id) deleteButtonRefs.current.set(calendar.id, el);
-                      else if (!el && calendar.id) deleteButtonRefs.current.delete(calendar.id);
+                      if (el && bookId) deleteButtonRefs.current.set(bookId, el);
+                      else if (!el && bookId) deleteButtonRefs.current.delete(bookId);
                     }}
-                    onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id ?? null); }}
+                    onClick={(e) => { e.stopPropagation(); setConfirmingId(bookId ?? null); }}
                     disabled={!!deletingId}
                     className={styles.deleteButton}
                     aria-label={`Delete ${bookName}`}

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -18,12 +18,12 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const router = useRouter();
 
-  // Auto-dismiss confirmation after 5 seconds
+  // Auto-dismiss confirmation after 5 seconds, but keep it visible while deletion is in progress
   useEffect(() => {
-    if (!confirmingId) return;
+    if (!confirmingId || deletingId === confirmingId) return;
     const timer = setTimeout(() => setConfirmingId(null), 5000);
     return () => clearTimeout(timer);
-  }, [confirmingId]);
+  }, [confirmingId, deletingId]);
 
   const handleCalendarClick = (calendar: Calendar) => {
     if (calendar.id) {

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Calendar } from '@/lib/graphService';
 import { getCalendarDisplayName } from '@/lib/calendarUtils';
@@ -15,7 +15,15 @@ interface CalendarListProps {
 
 export default function CalendarList({ calendars, loading, error, onDeleteCalendar }: CalendarListProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const router = useRouter();
+
+  // Auto-dismiss confirmation after 5 seconds
+  useEffect(() => {
+    if (!confirmingId) return;
+    const timer = setTimeout(() => setConfirmingId(null), 5000);
+    return () => clearTimeout(timer);
+  }, [confirmingId]);
 
   const handleCalendarClick = (calendar: Calendar) => {
     if (calendar.id) {
@@ -23,13 +31,8 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
     }
   };
 
-  const handleDelete = async (calendar: Calendar) => {
+  const handleDelete = useCallback(async (calendar: Calendar) => {
     if (!calendar.id) return;
-    
-    const displayName = getCalendarDisplayName(calendar);
-    if (!confirm(`Are you sure you want to delete "${displayName}"?`)) {
-      return;
-    }
 
     setDeletingId(calendar.id);
     try {
@@ -39,8 +42,9 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
       alert('Failed to delete book. Please try again.');
     } finally {
       setDeletingId(null);
+      setConfirmingId(null);
     }
-  };
+  }, [onDeleteCalendar]);
   if (loading) {
     return (
       <div className={styles.loading}>
@@ -130,13 +134,31 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
               </p>
             )}
             <div className={styles.calendarFooter}>
-              <button
-                onClick={(e) => { e.stopPropagation(); handleDelete(calendar); }}
-                disabled={deletingId === calendar.id}
-                className={styles.deleteButton}
-              >
-                {deletingId === calendar.id ? 'Deleting...' : 'Delete Book'}
-              </button>
+              {confirmingId === calendar.id ? (
+                <div className={styles.deleteConfirmRow}>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setConfirmingId(null); }}
+                    className={styles.deleteCancelButton}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleDelete(calendar); }}
+                    disabled={deletingId === calendar.id}
+                    className={styles.deleteConfirmButton}
+                  >
+                    {deletingId === calendar.id ? 'Deleting...' : 'Confirm Delete'}
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id!); }}
+                  disabled={deletingId === calendar.id}
+                  className={styles.deleteButton}
+                >
+                  🗑 Delete
+                </button>
+              )}
             </div>
           </div>
         ))}

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -42,7 +42,7 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
       alert('Failed to delete book. Please try again.');
     } finally {
       setDeletingId(null);
-      setConfirmingId(null);
+      setConfirmingId(prev => prev === calendar.id ? null : prev);
     }
   }, [onDeleteCalendar]);
   if (loading) {
@@ -134,30 +134,36 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
               </p>
             )}
             <div className={styles.calendarFooter}>
-              {confirmingId === calendar.id ? (
-                <div className={styles.deleteConfirmRow}>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); setConfirmingId(null); }}
-                    className={styles.deleteCancelButton}
+              {calendar.id && (
+                confirmingId === calendar.id ? (
+                  <div
+                    className={styles.deleteConfirmRow}
+                    onClick={(e) => e.stopPropagation()}
+                    onMouseDown={(e) => e.stopPropagation()}
                   >
-                    Cancel
-                  </button>
+                    <button
+                      onClick={() => setConfirmingId(null)}
+                      className={styles.deleteCancelButton}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => handleDelete(calendar)}
+                      disabled={deletingId === calendar.id}
+                      className={styles.deleteConfirmButton}
+                    >
+                      {deletingId === calendar.id ? 'Deleting...' : 'Confirm Delete'}
+                    </button>
+                  </div>
+                ) : (
                   <button
-                    onClick={(e) => { e.stopPropagation(); handleDelete(calendar); }}
+                    onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id ?? null); }}
                     disabled={deletingId === calendar.id}
-                    className={styles.deleteConfirmButton}
+                    className={styles.deleteButton}
                   >
-                    {deletingId === calendar.id ? 'Deleting...' : 'Confirm Delete'}
+                    🗑 Delete
                   </button>
-                </div>
-              ) : (
-                <button
-                  onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id!); }}
-                  disabled={deletingId === calendar.id}
-                  className={styles.deleteButton}
-                >
-                  🗑 Delete
-                </button>
+                )
               )}
             </div>
           </div>

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { Calendar } from '@/lib/graphService';
 import { getCalendarDisplayName } from '@/lib/calendarUtils';
@@ -16,6 +16,7 @@ interface CalendarListProps {
 export default function CalendarList({ calendars, loading, error, onDeleteCalendar }: CalendarListProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
 
   // Auto-dismiss confirmation after 5 seconds, but keep it visible while deletion is in progress
@@ -24,6 +25,13 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
     const timer = setTimeout(() => setConfirmingId(null), 5000);
     return () => clearTimeout(timer);
   }, [confirmingId, deletingId]);
+
+  // Move focus to the Confirm Delete button when confirmation row appears
+  useEffect(() => {
+    if (confirmingId) {
+      confirmButtonRef.current?.focus();
+    }
+  }, [confirmingId]);
 
   const handleCalendarClick = (calendar: Calendar) => {
     if (calendar.id) {
@@ -143,11 +151,13 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                   >
                     <button
                       onClick={() => setConfirmingId(null)}
+                      disabled={deletingId === calendar.id}
                       className={styles.deleteCancelButton}
                     >
                       Cancel
                     </button>
                     <button
+                      ref={confirmingId === calendar.id ? confirmButtonRef : undefined}
                       onClick={() => handleDelete(calendar)}
                       disabled={deletingId === calendar.id}
                       className={styles.deleteConfirmButton}

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -56,7 +56,15 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
       alert('Failed to delete book. Please try again.');
     } finally {
       setDeletingId(null);
-      setConfirmingId(prev => prev === calendar.id ? null : prev);
+      setConfirmingId(prev => {
+        if (prev === calendar.id) {
+          // Restore focus to delete button if the calendar still exists (e.g., on failure)
+          const btn = deleteButtonRefs.current.get(calendar.id!);
+          if (btn) requestAnimationFrame(() => btn.focus());
+          return null;
+        }
+        return prev;
+      });
     }
   }, [onDeleteCalendar]);
   if (loading) {
@@ -177,7 +185,10 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                   </div>
                 ) : (
                   <button
-                    ref={(el) => { if (el && calendar.id) deleteButtonRefs.current.set(calendar.id, el); }}
+                    ref={(el) => {
+                      if (el && calendar.id) deleteButtonRefs.current.set(calendar.id, el);
+                      else if (!el && calendar.id) deleteButtonRefs.current.delete(calendar.id);
+                    }}
                     onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id ?? null); }}
                     disabled={!!deletingId}
                     className={styles.deleteButton}

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -17,12 +17,18 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const deleteButtonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const router = useRouter();
 
   // Auto-dismiss confirmation after 5 seconds, but keep it visible while deletion is in progress
   useEffect(() => {
     if (!confirmingId || deletingId === confirmingId) return;
-    const timer = setTimeout(() => setConfirmingId(null), 5000);
+    const timer = setTimeout(() => {
+      setConfirmingId(null);
+      // Restore focus to the delete button after auto-dismiss
+      const btn = deleteButtonRefs.current.get(confirmingId);
+      if (btn) requestAnimationFrame(() => btn.focus());
+    }, 5000);
     return () => clearTimeout(timer);
   }, [confirmingId, deletingId]);
 
@@ -150,8 +156,12 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                     onMouseDown={(e) => e.stopPropagation()}
                   >
                     <button
-                      onClick={() => setConfirmingId(null)}
-                      disabled={deletingId === calendar.id}
+                      onClick={() => {
+                        setConfirmingId(null);
+                        const btn = deleteButtonRefs.current.get(calendar.id!);
+                        if (btn) requestAnimationFrame(() => btn.focus());
+                      }}
+                      disabled={!!deletingId}
                       className={styles.deleteCancelButton}
                     >
                       Cancel
@@ -159,7 +169,7 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                     <button
                       ref={confirmingId === calendar.id ? confirmButtonRef : undefined}
                       onClick={() => handleDelete(calendar)}
-                      disabled={deletingId === calendar.id}
+                      disabled={!!deletingId}
                       className={styles.deleteConfirmButton}
                     >
                       {deletingId === calendar.id ? 'Deleting...' : 'Confirm Delete'}
@@ -167,8 +177,9 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                   </div>
                 ) : (
                   <button
+                    ref={(el) => { if (el && calendar.id) deleteButtonRefs.current.set(calendar.id, el); }}
                     onClick={(e) => { e.stopPropagation(); setConfirmingId(calendar.id ?? null); }}
-                    disabled={deletingId === calendar.id}
+                    disabled={!!deletingId}
                     className={styles.deleteButton}
                   >
                     🗑 Delete

--- a/src/arrange-v4/components/CalendarList.tsx
+++ b/src/arrange-v4/components/CalendarList.tsx
@@ -16,21 +16,29 @@ interface CalendarListProps {
 export default function CalendarList({ calendars, loading, error, onDeleteCalendar }: CalendarListProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [dismissResetKey, setDismissResetKey] = useState(0);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const deleteButtonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const router = useRouter();
 
-  // Auto-dismiss confirmation after 5 seconds, but keep it visible while deletion is in progress
+  // Auto-dismiss confirmation after 5 seconds of inactivity
   useEffect(() => {
     if (!confirmingId || deletingId === confirmingId) return;
+    const savedId = confirmingId;
     const timer = setTimeout(() => {
       setConfirmingId(null);
-      // Restore focus to the delete button after auto-dismiss
-      const btn = deleteButtonRefs.current.get(confirmingId);
-      if (btn) requestAnimationFrame(() => btn.focus());
+      // Defer focus restoration until delete button remounts
+      requestAnimationFrame(() => {
+        const btn = deleteButtonRefs.current.get(savedId);
+        if (btn) btn.focus();
+      });
     }, 5000);
     return () => clearTimeout(timer);
-  }, [confirmingId, deletingId]);
+  }, [confirmingId, deletingId, dismissResetKey]);
+
+  const resetDismissTimer = useCallback(() => {
+    setDismissResetKey(k => k + 1);
+  }, []);
 
   // Move focus to the Confirm Delete button when confirmation row appears
   useEffect(() => {
@@ -58,10 +66,12 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
       const calId = calendar.id;
       setDeletingId(null);
       setConfirmingId(prev => prev === calId ? null : prev);
-      // Restore focus to delete button if the calendar still exists (e.g., on failure)
+      // Defer focus restoration until delete button remounts after confirmation row unmounts
       if (calId) {
-        const btn = deleteButtonRefs.current.get(calId);
-        if (btn) requestAnimationFrame(() => btn.focus());
+        requestAnimationFrame(() => {
+          const btn = deleteButtonRefs.current.get(calId);
+          if (btn) btn.focus();
+        });
       }
     }
   }, [onDeleteCalendar]);
@@ -162,14 +172,16 @@ export default function CalendarList({ calendars, loading, error, onDeleteCalend
                     className={styles.deleteConfirmRow}
                     onClick={(e) => e.stopPropagation()}
                     onMouseDown={(e) => e.stopPropagation()}
-                    onMouseMove={() => setConfirmingId(bookId)}
-                    onFocus={() => setConfirmingId(bookId)}
+                    onMouseMove={resetDismissTimer}
+                    onFocus={resetDismissTimer}
                   >
                     <button
                       onClick={() => {
                         setConfirmingId(null);
-                        const btn = deleteButtonRefs.current.get(bookId);
-                        if (btn) requestAnimationFrame(() => btn.focus());
+                        requestAnimationFrame(() => {
+                          const btn = deleteButtonRefs.current.get(bookId);
+                          if (btn) btn.focus();
+                        });
                       }}
                       disabled={!!deletingId}
                       className={styles.deleteCancelButton}


### PR DESCRIPTION
## Summary

The "Delete Book" button in the book manager was too easy to accidentally click (issue #33). This replaces the dangerous one-click + native `confirm()` pattern with a safer two-step inline confirmation.

### Changes

- **Subdued initial button**: Small gray "🗑 Delete" text instead of full-width red — only turns red on hover
- **Inline confirmation**: First click reveals "Cancel" + "Confirm Delete" side-by-side buttons
- **Auto-dismiss**: Confirmation row disappears after 5 seconds of inactivity
- **Removed native `confirm()`**: The inline confirmation replaces it

### Files Changed
- `components/CalendarList.tsx` — inline confirmation state, auto-dismiss effect, two-step UI
- `components/CalendarList.module.css` — subdued delete button styles, confirmation row styles

Closes #33