### PR TITLE
feat: Add cancelled tasks view with bulk delete (Issue #14)

### DIFF
--- a/devnotes/BugNotes.md
+++ b/devnotes/BugNotes.md
@@ -1,0 +1,28 @@
+# Bug Notes
+
+Lessons learned from bugs encountered during development — documented here so we don't repeat them.
+
+## HamburgerMenu: hardcoded `/matrix` assumptions
+
+**When:** Adding the Cancelled Tasks nav entry (Issue #14)
+
+**Root cause:** `HamburgerMenu.tsx` had two places that assumed `/matrix` was the only `matchPrefix` nav item:
+
+1. **`isActive()`** — used `pathname.startsWith('/matrix')` for *all* `matchPrefix` items, so every prefix-matched page highlighted whenever `/matrix` was active (and vice versa).
+2. **`useEffect` building nav hrefs** — replaced the href of *all* `matchPrefix` items with `` `/matrix?bookId=...` `` instead of preserving each item's own route prefix.
+
+**Symptoms:**
+- Duplicate React key warning in the console (`Encountered two children with the same key`).
+- Both Matrix and Cancelled Tasks highlighted at the same time in the sidebar.
+
+**Fix:** Use each item's own `href` as the base:
+```tsx
+// isActive — derive base path from the item, not a constant
+const basePath = item.href.split('?')[0];
+return pathname.startsWith(basePath);
+
+// href builder — use item.href, not '/matrix'
+{ ...item, href: `${item.href}?bookId=${encodeURIComponent(savedBookId)}` }
+```
+
+**Takeaway:** When adding a new nav item with `matchPrefix: true`, check every code path in `HamburgerMenu.tsx` that branches on `matchPrefix` — none should reference a specific route string.

--- a/src/arrange-v4/app/books/page.tsx
+++ b/src/arrange-v4/app/books/page.tsx
@@ -1,26 +1,23 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useMsal } from '@azure/msal-react';
-import { loginRequest } from '@/lib/msalConfig';
 import { getCalendars, getUserInfo, createCalendar, deleteCalendar, Calendar } from '@/lib/graphService';
 import { filterArrangeCalendars } from '@/lib/calendarUtils';
+import { useGraphToken } from '@/lib/hooks/useGraphToken';
 import CalendarList from '@/components/CalendarList';
 import CreateCalendar from '@/components/CreateCalendar';
 import styles from './page.module.css';
 
 export default function BooksPage() {
-  const { instance, accounts, inProgress } = useMsal();
+  const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin, instance } = useGraphToken();
   const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [userName, setUserName] = useState<string>('');
 
-  const isAuthenticated = accounts.length > 0;
-
   const handleLogin = async () => {
     try {
-      await instance.loginPopup(loginRequest);
+      await graphLogin();
     } catch (error) {
       console.error('Login failed:', error);
       setError('Login failed. Please try again.');
@@ -40,35 +37,19 @@ export default function BooksPage() {
     setError(null);
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
+      const accessToken = await acquireToken();
 
       // Fetch user info
-      const userInfo = await getUserInfo(response.accessToken);
+      const userInfo = await getUserInfo(accessToken);
       setUserName(userInfo.displayName || userInfo.userPrincipalName || '');
 
       // Fetch calendars and filter arrange books
-      const calendarsData = await getCalendars(response.accessToken);
+      const calendarsData = await getCalendars(accessToken);
       const filteredCalendars = filterArrangeCalendars(calendarsData);
       setCalendars(filteredCalendars);
     } catch (error: any) {
       console.error('Error fetching calendars:', error);
       setError(error.message || 'Failed to fetch books');
-      
-      // If token acquisition fails, try interactive login
-      if (error.name === 'InteractionRequiredAuthError') {
-        try {
-          const response = await instance.acquireTokenPopup(loginRequest);
-          const calendarsData = await getCalendars(response.accessToken);
-          const filteredCalendars = filterArrangeCalendars(calendarsData);
-          setCalendars(filteredCalendars);
-        } catch (popupError: any) {
-          setError(popupError.message || 'Failed to fetch books');
-        }
-      }
     } finally {
       setLoading(false);
     }
@@ -76,13 +57,8 @@ export default function BooksPage() {
 
   const handleCreateCalendar = async (name: string) => {
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
-
-      const newCalendar = await createCalendar(response.accessToken, name);
+      const accessToken = await acquireToken();
+      const newCalendar = await createCalendar(accessToken, name);
       setCalendars(prev => [...prev, newCalendar]);
     } catch (error: any) {
       console.error('Error creating calendar:', error);
@@ -92,13 +68,8 @@ export default function BooksPage() {
 
   const handleDeleteCalendar = async (calendarId: string) => {
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
-
-      await deleteCalendar(response.accessToken, calendarId);
+      const accessToken = await acquireToken();
+      await deleteCalendar(accessToken, calendarId);
       setCalendars(prev => prev.filter(c => c.id !== calendarId));
     } catch (error: any) {
       console.error('Error deleting calendar:', error);

--- a/src/arrange-v4/app/cancelled/page.module.css
+++ b/src/arrange-v4/app/cancelled/page.module.css
@@ -210,6 +210,7 @@
   padding: 12px 16px;
   border-bottom: 1px solid #f3f4f6;
   transition: background-color 0.15s;
+  cursor: pointer;
 }
 
 .taskRow:last-child {

--- a/src/arrange-v4/app/cancelled/page.module.css
+++ b/src/arrange-v4/app/cancelled/page.module.css
@@ -342,10 +342,6 @@
     padding: 10px 12px;
   }
 
-  .unauthCard {
-    padding: 32px 24px;
-  }
-
   .confirmDialog {
     padding: 24px;
   }

--- a/src/arrange-v4/app/cancelled/page.module.css
+++ b/src/arrange-v4/app/cancelled/page.module.css
@@ -1,0 +1,373 @@
+.container {
+  min-height: 100vh;
+  background-color: #f9fafb;
+}
+
+.inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 32px 16px;
+}
+
+.card {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-size: 1.875rem;
+  font-weight: bold;
+  color: #111827;
+}
+
+.subtitle {
+  color: #4b5563;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.button {
+  font-weight: 500;
+  padding: 8px 24px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.875rem;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.buttonPrimary {
+  background-color: #2563eb;
+  color: white;
+}
+
+.buttonPrimary:hover:not(:disabled) {
+  background-color: #1d4ed8;
+}
+
+.buttonSecondary {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.buttonSecondary:hover:not(:disabled) {
+  background-color: #d1d5db;
+}
+
+.buttonDanger {
+  background-color: #dc2626;
+  color: white;
+}
+
+.buttonDanger:hover:not(:disabled) {
+  background-color: #b91c1c;
+}
+
+/* Error / loading / empty */
+.error {
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-bottom: 16px;
+}
+
+.errorTitle {
+  font-weight: bold;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 32px;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid #e5e7eb;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.empty {
+  text-align: center;
+  padding: 40px 32px;
+  color: #6b7280;
+}
+
+.emptyTitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px;
+}
+
+.emptyHint {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Warning (no book selected) */
+.warning {
+  background-color: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  padding: 16px 24px;
+  border-radius: 8px;
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.warningLink {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+/* Unauth card */
+.unauthCard {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  padding: 48px;
+  text-align: center;
+}
+
+.unauthTitle {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 16px;
+}
+
+.unauthDescription {
+  color: #4b5563;
+  margin-bottom: 24px;
+  line-height: 1.6;
+}
+
+/* Book switcher */
+.bookSwitcher {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #374151;
+  background-color: white;
+  cursor: pointer;
+}
+
+/* Task list */
+.taskList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.taskRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #f3f4f6;
+  transition: background-color 0.15s;
+}
+
+.taskRow:last-child {
+  border-bottom: none;
+}
+
+.taskRow:hover {
+  background-color: #f9fafb;
+}
+
+.taskRowSelected {
+  background-color: #eff6ff;
+}
+
+.taskRowSelected:hover {
+  background-color: #dbeafe;
+}
+
+.taskCheckbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+  accent-color: #2563eb;
+}
+
+.taskInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.taskSubject {
+  font-weight: 500;
+  color: #111827;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.taskMeta {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.taskCategories {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.taskCategory {
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+/* Select-all header */
+.selectAllRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  border-bottom: 2px solid #e5e7eb;
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+/* Toolbar (delete button area) */
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.selectionInfo {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+/* Confirmation overlay */
+.confirmOverlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 50;
+}
+
+.confirmDialog {
+  background-color: white;
+  border-radius: 12px;
+  padding: 32px;
+  max-width: 480px;
+  width: 90%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.confirmTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 12px;
+}
+
+.confirmMessage {
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 24px;
+}
+
+.confirmActions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+/* Deleting progress */
+.deletingInfo {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 8px;
+}
+
+@media (max-width: 600px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .actions {
+    flex-wrap: wrap;
+  }
+
+  .inner {
+    padding: 16px;
+  }
+
+  .taskRow {
+    padding: 10px 12px;
+  }
+
+  .unauthCard {
+    padding: 32px 24px;
+  }
+
+  .confirmDialog {
+    padding: 24px;
+  }
+}

--- a/src/arrange-v4/app/cancelled/page.module.css
+++ b/src/arrange-v4/app/cancelled/page.module.css
@@ -163,28 +163,6 @@
   text-decoration: underline;
 }
 
-/* Unauth card */
-.unauthCard {
-  background-color: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  padding: 48px;
-  text-align: center;
-}
-
-.unauthTitle {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: #374151;
-  margin-bottom: 16px;
-}
-
-.unauthDescription {
-  color: #4b5563;
-  margin-bottom: 24px;
-  line-height: 1.6;
-}
-
 /* Book switcher */
 .bookSwitcher {
   padding: 4px 8px;

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useMemo, useRef, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react';
 import { getAllCalendarEvents } from '@/lib/graphService';
 import { deleteTodoItem, TodoItem, parseTodoData } from '@/lib/todoDataService';
 import { getCalendarDisplayName } from '@/lib/calendarUtils';
@@ -14,7 +14,7 @@ function CancelledPageContent() {
   const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin } = useGraphToken();
   const { bookId, calendars, currentCalendarName, handleCalendarSwitch, error: calendarError } = useBookId('/cancelled');
 
-  const [todoItems, setTodoItems] = useState<(TodoItem & { id?: string })[]>([]);
+  const [cancelledItems, setCancelledItems] = useState<(TodoItem & { id?: string })[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -26,14 +26,9 @@ function CancelledPageContent() {
 
   const displayError = error || calendarError;
 
-  const cancelledItems = useMemo(
-    () => todoItems.filter(t => t.status === 'cancelled'),
-    [todoItems],
-  );
-
   const allSelected = cancelledItems.length > 0 && cancelledItems.every(t => t.id && selectedIds.has(t.id));
 
-  const fetchEvents = async () => {
+  const fetchEvents = useCallback(async () => {
     if (!isAuthenticated || !bookId) return;
 
     setLoading(true);
@@ -43,7 +38,7 @@ function CancelledPageContent() {
       const accessToken = await acquireToken();
       const eventsData = await getAllCalendarEvents(accessToken, bookId);
       const todos = eventsData.map(event => parseTodoData(event));
-      setTodoItems(todos);
+      setCancelledItems(todos.filter(t => t.status === 'cancelled'));
       setSelectedIds(new Set());
     } catch (err: unknown) {
       console.error('Error fetching events:', err);
@@ -52,14 +47,13 @@ function CancelledPageContent() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [isAuthenticated, bookId, acquireToken]);
 
   useEffect(() => {
     if (isAuthenticated && inProgress === 'none' && bookId) {
       fetchEvents();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated, inProgress, bookId]);
+  }, [isAuthenticated, inProgress, bookId, fetchEvents]);
 
   const toggleSelect = (id: string) => {
     setSelectedIds(prev => {
@@ -97,8 +91,8 @@ function CancelledPageContent() {
     setDeleteProgress({ done: 0, total: idsToDelete.length });
 
     // Optimistic removal — keep a snapshot for rollback
-    const previousItems = [...todoItems];
-    setTodoItems(items => items.filter(item => !item.id || !selectedIds.has(item.id)));
+    const previousItems = [...cancelledItems];
+    setCancelledItems(items => items.filter(item => !item.id || !selectedIds.has(item.id)));
 
     const CONCURRENCY = 5;
     let idx = 0;
@@ -127,9 +121,8 @@ function CancelledPageContent() {
       );
 
       if (hasFailure) {
-        // Some deletions failed — re-fetch to get accurate state
-        setError('Some items could not be deleted. Refreshing list.');
         await fetchEvents();
+        setError('Some items could not be deleted. The list has been refreshed.');
       } else {
         setSelectedIds(new Set());
       }
@@ -137,8 +130,7 @@ function CancelledPageContent() {
       console.error('Error during bulk delete:', err);
       const message = err instanceof Error ? err.message : 'Failed to delete items';
       setError(message);
-      // Rollback optimistic removal
-      setTodoItems(previousItems);
+      setCancelledItems(previousItems);
     } finally {
       setDeleting(false);
       setShowConfirm(false);
@@ -317,9 +309,16 @@ function CancelledPageContent() {
         {/* Confirmation dialog */}
         {showConfirm && (
           <div className={styles.confirmOverlay} onClick={() => !deleting && setShowConfirm(false)}>
-            <div className={styles.confirmDialog} onClick={e => e.stopPropagation()}>
-              <h2 className={styles.confirmTitle}>Delete {selectedIds.size} {selectedIds.size === 1 ? 'task' : 'tasks'}?</h2>
-              <p className={styles.confirmMessage}>
+            <div
+              className={styles.confirmDialog}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="cancelled-delete-confirm-title"
+              aria-describedby="cancelled-delete-confirm-message"
+              onClick={e => e.stopPropagation()}
+            >
+              <h2 id="cancelled-delete-confirm-title" className={styles.confirmTitle}>Delete {selectedIds.size} {selectedIds.size === 1 ? 'task' : 'tasks'}?</h2>
+              <p id="cancelled-delete-confirm-message" className={styles.confirmMessage}>
                 This action cannot be undone. The selected cancelled tasks will be permanently removed from your calendar.
               </p>
               {deleting && (

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -170,6 +170,7 @@ function CancelledPageContent() {
                   className={styles.bookSwitcher}
                   value={bookId || ''}
                   onChange={(e) => handleCalendarSwitch(e.target.value)}
+                  disabled={loading || deleting}
                 >
                   {calendars.map(cal => (
                     <option key={cal.id} value={cal.id}>

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import React, { useState, useEffect, useMemo, useRef, Suspense } from 'react';
+import { getAllCalendarEvents } from '@/lib/graphService';
+import { deleteTodoItem, TodoItem, parseTodoData } from '@/lib/todoDataService';
+import { getCalendarDisplayName } from '@/lib/calendarUtils';
+import { useGraphToken } from '@/lib/hooks/useGraphToken';
+import { useBookId } from '@/lib/hooks/useBookId';
+import Link from 'next/link';
+import styles from './page.module.css';
+
+function CancelledPageContent() {
+  const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin } = useGraphToken();
+  const { bookId, calendars, currentCalendarName, handleCalendarSwitch, error: calendarError } = useBookId('/cancelled');
+
+  const [todoItems, setTodoItems] = useState<(TodoItem & { id?: string })[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteProgress, setDeleteProgress] = useState({ done: 0, total: 0 });
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  const displayError = error || calendarError;
+
+  const cancelledItems = useMemo(
+    () => todoItems.filter(t => t.status === 'cancelled'),
+    [todoItems],
+  );
+
+  const allSelected = cancelledItems.length > 0 && cancelledItems.every(t => t.id && selectedIds.has(t.id));
+
+  const fetchEvents = async () => {
+    if (!isAuthenticated || !bookId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const accessToken = await acquireToken();
+      const eventsData = await getAllCalendarEvents(accessToken, bookId);
+      const todos = eventsData.map(event => parseTodoData(event));
+      setTodoItems(todos);
+      setSelectedIds(new Set());
+    } catch (err: unknown) {
+      console.error('Error fetching events:', err);
+      const message = err instanceof Error ? err.message : 'Failed to fetch events';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isAuthenticated && inProgress === 'none' && bookId) {
+      fetchEvents();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, inProgress, bookId]);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(cancelledItems.filter(t => t.id).map(t => t.id!)));
+    }
+  };
+
+  const handleDeleteSelected = () => {
+    if (selectedIds.size === 0) return;
+    setShowConfirm(true);
+  };
+
+  // Focus the confirm button when the dialog appears
+  useEffect(() => {
+    if (showConfirm) {
+      confirmButtonRef.current?.focus();
+    }
+  }, [showConfirm]);
+
+  const confirmDelete = async () => {
+    if (!bookId || selectedIds.size === 0) return;
+
+    setDeleting(true);
+    const idsToDelete = Array.from(selectedIds);
+    setDeleteProgress({ done: 0, total: idsToDelete.length });
+
+    // Optimistic removal — keep a snapshot for rollback
+    const previousItems = [...todoItems];
+    setTodoItems(items => items.filter(item => !item.id || !selectedIds.has(item.id)));
+
+    const CONCURRENCY = 5;
+    let idx = 0;
+    let completed = 0;
+    let hasFailure = false;
+
+    try {
+      const accessToken = await acquireToken();
+
+      const worker = async () => {
+        while (idx < idsToDelete.length) {
+          const eventId = idsToDelete[idx++];
+          try {
+            await deleteTodoItem(accessToken, bookId, eventId);
+          } catch (err) {
+            hasFailure = true;
+            console.error(`Error deleting event ${eventId}:`, err);
+          }
+          completed++;
+          setDeleteProgress({ done: completed, total: idsToDelete.length });
+        }
+      };
+
+      await Promise.all(
+        Array.from({ length: Math.min(CONCURRENCY, idsToDelete.length) }, () => worker()),
+      );
+
+      if (hasFailure) {
+        // Some deletions failed — re-fetch to get accurate state
+        setError('Some items could not be deleted. Refreshing list.');
+        await fetchEvents();
+      } else {
+        setSelectedIds(new Set());
+      }
+    } catch (err: unknown) {
+      console.error('Error during bulk delete:', err);
+      const message = err instanceof Error ? err.message : 'Failed to delete items';
+      setError(message);
+      // Rollback optimistic removal
+      setTodoItems(previousItems);
+    } finally {
+      setDeleting(false);
+      setShowConfirm(false);
+    }
+  };
+
+  const handleLogin = async () => {
+    try {
+      await graphLogin();
+    } catch (err) {
+      console.error('Login failed:', err);
+      setError('Login failed. Please try again.');
+    }
+  };
+
+  if (!bookId) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.inner}>
+          <div className={styles.warning}>
+            No book selected. Please select a book from the <Link href="/books" className={styles.warningLink}>Books page</Link>.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <div className={styles.card}>
+          <div className={styles.header}>
+            <div className={styles.headerInfo}>
+              <h1 className={styles.title}>Cancelled Tasks</h1>
+              {calendars.length > 1 ? (
+                <select
+                  className={styles.bookSwitcher}
+                  value={bookId || ''}
+                  onChange={(e) => handleCalendarSwitch(e.target.value)}
+                >
+                  {calendars.map(cal => (
+                    <option key={cal.id} value={cal.id}>
+                      {getCalendarDisplayName(cal)}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <p className={styles.subtitle}>{currentCalendarName}</p>
+              )}
+            </div>
+            <div className={styles.actions}>
+              {!isAuthenticated ? (
+                <button
+                  onClick={handleLogin}
+                  disabled={inProgress !== 'none'}
+                  className={`${styles.button} ${styles.buttonPrimary}`}
+                >
+                  {inProgress !== 'none' ? 'Signing in...' : 'Sign In'}
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={handleDeleteSelected}
+                    disabled={loading || selectedIds.size === 0 || deleting}
+                    className={`${styles.button} ${styles.buttonDanger}`}
+                  >
+                    Delete Selected ({selectedIds.size})
+                  </button>
+                  <button
+                    onClick={fetchEvents}
+                    disabled={loading}
+                    className={`${styles.button} ${styles.buttonSecondary}`}
+                  >
+                    {loading ? 'Loading...' : 'Refresh'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {displayError && (
+          <div className={styles.error} role="alert">
+            <span className={styles.errorTitle}>Error: </span>
+            <span>{displayError}</span>
+          </div>
+        )}
+
+        {loading && (
+          <div className={styles.loading}>
+            <div className={styles.spinner}></div>
+          </div>
+        )}
+
+        {!loading && isAuthenticated && (
+          <div className={styles.card}>
+            {cancelledItems.length === 0 ? (
+              <div className={styles.empty}>
+                <p className={styles.emptyTitle}>No cancelled tasks</p>
+                <p className={styles.emptyHint}>
+                  Tasks you cancel in the Matrix view will appear here for review and deletion.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className={styles.toolbar}>
+                  <span className={styles.selectionInfo}>
+                    {cancelledItems.length} cancelled {cancelledItems.length === 1 ? 'task' : 'tasks'}
+                  </span>
+                </div>
+                <div className={styles.taskList}>
+                  <div className={styles.selectAllRow}>
+                    <input
+                      type="checkbox"
+                      className={styles.taskCheckbox}
+                      checked={allSelected}
+                      onChange={toggleSelectAll}
+                      aria-label="Select all cancelled tasks"
+                    />
+                    <span>Select all</span>
+                  </div>
+                  {cancelledItems.map(todo => {
+                    const isSelected = !!todo.id && selectedIds.has(todo.id);
+                    return (
+                      <div
+                        key={todo.id}
+                        className={`${styles.taskRow} ${isSelected ? styles.taskRowSelected : ''}`}
+                      >
+                        <input
+                          type="checkbox"
+                          className={styles.taskCheckbox}
+                          checked={isSelected}
+                          onChange={() => todo.id && toggleSelect(todo.id)}
+                          aria-label={`Select ${todo.subject}`}
+                        />
+                        <div className={styles.taskInfo}>
+                          <div className={styles.taskSubject}>{todo.subject}</div>
+                          <div className={styles.taskMeta}>
+                            {todo.etsDateTime && (
+                              <span>ETS: {new Date(todo.etsDateTime).toLocaleDateString()}</span>
+                            )}
+                            {todo.etaDateTime && (
+                              <span>ETA: {new Date(todo.etaDateTime).toLocaleDateString()}</span>
+                            )}
+                          </div>
+                        </div>
+                        {todo.categories && todo.categories.length > 0 && (
+                          <div className={styles.taskCategories}>
+                            {todo.categories.map(cat => (
+                              <span key={cat} className={styles.taskCategory}>{cat}</span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Confirmation dialog */}
+        {showConfirm && (
+          <div className={styles.confirmOverlay} onClick={() => !deleting && setShowConfirm(false)}>
+            <div className={styles.confirmDialog} onClick={e => e.stopPropagation()}>
+              <h2 className={styles.confirmTitle}>Delete {selectedIds.size} {selectedIds.size === 1 ? 'task' : 'tasks'}?</h2>
+              <p className={styles.confirmMessage}>
+                This action cannot be undone. The selected cancelled tasks will be permanently removed from your calendar.
+              </p>
+              {deleting && (
+                <p className={styles.deletingInfo}>
+                  Deleting… {deleteProgress.done} of {deleteProgress.total}
+                </p>
+              )}
+              <div className={styles.confirmActions}>
+                <button
+                  onClick={() => setShowConfirm(false)}
+                  disabled={deleting}
+                  className={`${styles.button} ${styles.buttonSecondary}`}
+                >
+                  Cancel
+                </button>
+                <button
+                  ref={confirmButtonRef}
+                  onClick={confirmDelete}
+                  disabled={deleting}
+                  className={`${styles.button} ${styles.buttonDanger}`}
+                >
+                  {deleting ? 'Deleting…' : 'Delete'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function CancelledPage() {
+  return (
+    <Suspense>
+      <CancelledPageContent />
+    </Suspense>
+  );
+}

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -354,7 +354,13 @@ function CancelledPageContent() {
 
 export default function CancelledPage() {
   return (
-    <Suspense>
+    <Suspense fallback={
+      <div className={styles.container}>
+        <div className={styles.inner}>
+          <div className={styles.loading}><div className={styles.spinner}></div></div>
+        </div>
+      </div>
+    }>
       <CancelledPageContent />
     </Suspense>
   );

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -6,6 +6,7 @@ import { deleteTodoItem, TodoItem, parseTodoData } from '@/lib/todoDataService';
 import { getCalendarDisplayName } from '@/lib/calendarUtils';
 import { useGraphToken } from '@/lib/hooks/useGraphToken';
 import { useBookId } from '@/lib/hooks/useBookId';
+import ViewTodoItem from '@/components/ViewTodoItem';
 import Link from 'next/link';
 import styles from './page.module.css';
 
@@ -20,6 +21,7 @@ function CancelledPageContent() {
   const [showConfirm, setShowConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteProgress, setDeleteProgress] = useState({ done: 0, total: 0 });
+  const [selectedTodo, setSelectedTodo] = useState<(TodoItem & { id?: string }) | null>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const displayError = error || calendarError;
@@ -264,12 +266,17 @@ function CancelledPageContent() {
                       <div
                         key={todo.id}
                         className={`${styles.taskRow} ${isSelected ? styles.taskRowSelected : ''}`}
+                        onClick={() => setSelectedTodo(todo)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedTodo(todo); } }}
                       >
                         <input
                           type="checkbox"
                           className={styles.taskCheckbox}
                           checked={isSelected}
                           onChange={() => todo.id && toggleSelect(todo.id)}
+                          onClick={(e) => e.stopPropagation()}
                           aria-label={`Select ${todo.subject}`}
                         />
                         <div className={styles.taskInfo}>
@@ -297,6 +304,14 @@ function CancelledPageContent() {
               </>
             )}
           </div>
+        )}
+
+        {/* Detail view dialog (read-only) */}
+        {selectedTodo && (
+          <ViewTodoItem
+            todo={selectedTodo}
+            onClose={() => setSelectedTodo(null)}
+          />
         )}
 
         {/* Confirmation dialog */}

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
-import { useMsal } from '@azure/msal-react';
-import { loginRequest } from '@/lib/msalConfig';
-import { getCalendars, getCalendarEvents, Calendar } from '@/lib/graphService';
+import React, { useState, useEffect, useMemo, useRef, Suspense } from 'react';
+import { getCalendars, getCalendarEvents } from '@/lib/graphService';
 import { createTodoItem, updateTodoItem, sweepStaleTodos, TodoItem, parseTodoData, TodoStatus, ALL_STATUSES, STATUS_LABELS } from '@/lib/todoDataService';
 import { filterArrangeCalendars, getCalendarDisplayName } from '@/lib/calendarUtils';
-import { getLastBookId, setLastBookId, clearLastBookId, hasSessionSweepRun, isSessionSweepInProgress, markSessionSweepInProgress, clearSessionSweepInProgress, markSessionSweepDone } from '@/lib/bookStorage';
+import { hasSessionSweepRun, isSessionSweepInProgress, markSessionSweepInProgress, clearSessionSweepInProgress, markSessionSweepDone } from '@/lib/bookStorage';
+import { useGraphToken } from '@/lib/hooks/useGraphToken';
+import { useBookId } from '@/lib/hooks/useBookId';
 import AddTodoItem from '@/components/AddTodoItem';
 import ViewTodoItem from '@/components/ViewTodoItem';
 import ManageTags from '@/components/ManageTags';
@@ -184,23 +183,12 @@ export default function MatrixPage() {
 }
 
 function MatrixPageContent() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const bookId = searchParams.get('bookId');
+  const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin, instance } = useGraphToken();
+  const { bookId, calendars, currentCalendarName, handleCalendarSwitch, error: calendarError, setError: setCalendarError } = useBookId('/matrix');
   const bookIdRef = useRef(bookId);
   const sweepAttemptedRef = useRef(false);
   bookIdRef.current = bookId;
 
-  useEffect(() => {
-    if (!bookId) {
-      const saved = getLastBookId();
-      if (saved) {
-        router.replace(`/matrix?bookId=${encodeURIComponent(saved)}`);
-      }
-    }
-  }, [bookId, router]);
-  
-  const { instance, accounts, inProgress } = useMsal();
   const [todoItems, setTodoItems] = useState<(TodoItem & { id?: string })[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -209,12 +197,12 @@ function MatrixPageContent() {
   const [statusFilters, setStatusFilters] = useState<Record<TodoStatus, StatusFilterMode>>(DEFAULT_STATUS_FILTERS);
   const [showFilters, setShowFilters] = useState(false);
   const [showTags, setShowTags] = useState(true);
-  const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [showUncategorized, setShowUncategorized] = useState(false);
   const [showManageTags, setShowManageTags] = useState(false);
 
-  const isAuthenticated = accounts.length > 0;
+  // Merge calendar-level errors into the page error state
+  const displayError = error || calendarError;
 
   const allCategories = useMemo(() => {
     const cats = new Set<string>();
@@ -251,49 +239,6 @@ function MatrixPageContent() {
     eliminate: filteredTodoItems.filter(todo => todo.urgent !== true && todo.important !== true),
   }), [filteredTodoItems]);
 
-  const currentCalendar = calendars.find(c => c.id === bookId);
-  const currentCalendarName = currentCalendar ? getCalendarDisplayName(currentCalendar) : bookId;
-
-  const fetchCalendars = useCallback(async () => {
-    if (!isAuthenticated) return;
-    try {
-      const account = accounts[0];
-      let accessToken: string;
-      try {
-        const response = await instance.acquireTokenSilent({ ...loginRequest, account });
-        accessToken = response.accessToken;
-      } catch (silentError: any) {
-        if (silentError.name === 'InteractionRequiredAuthError') {
-          const response = await instance.acquireTokenPopup(loginRequest);
-          accessToken = response.accessToken;
-        } else {
-          throw silentError;
-        }
-      }
-      const all = await getCalendars(accessToken);
-      const arrangeCalendars = filterArrangeCalendars(all);
-      setCalendars(arrangeCalendars);
-
-      if (bookId && !arrangeCalendars.some(c => c.id === bookId)) {
-        clearLastBookId();
-        router.replace('/books');
-      } else if (bookId && arrangeCalendars.some(c => c.id === bookId)) {
-        setLastBookId(bookId);
-      }
-    } catch (error: any) {
-      console.error('Error fetching calendars:', error);
-      setError(error.message || 'Failed to fetch calendars');
-    }
-  }, [isAuthenticated, accounts, instance, bookId, router]);
-
-  useEffect(() => {
-    fetchCalendars();
-  }, [fetchCalendars]);
-
-  const handleCalendarSwitch = (calendarId: string) => {
-    router.push(`/matrix?bookId=${encodeURIComponent(calendarId)}`);
-  };
-
   const fetchEvents = async () => {
     if (!isAuthenticated || !bookId) return;
 
@@ -301,11 +246,7 @@ function MatrixPageContent() {
     setError(null);
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
+      const accessToken = await acquireToken();
 
       // Fetch events from last 30 days to next 30 days
       const today = new Date();
@@ -314,7 +255,7 @@ function MatrixPageContent() {
       const endDate = new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000);
       
       const eventsData = await getCalendarEvents(
-        response.accessToken,
+        accessToken,
         bookId,
         startDate.toISOString(),
         endDate.toISOString()
@@ -328,7 +269,7 @@ function MatrixPageContent() {
       if (!hasSessionSweepRun() && !isSessionSweepInProgress() && !sweepAttemptedRef.current) {
         sweepAttemptedRef.current = true;
         markSessionSweepInProgress();
-        const sweepAccessToken = response.accessToken;
+        const sweepAccessToken = accessToken;
         const sweepBookId = bookId;
         const snapshotCalendars = calendars.length > 0 ? [...calendars] : null;
         void (async () => {
@@ -396,13 +337,9 @@ function MatrixPageContent() {
     }
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
+      const accessToken = await acquireToken();
 
-      const createdEvent = await createTodoItem(response.accessToken, bookId, todoItem);
+      const createdEvent = await createTodoItem(accessToken, bookId, todoItem);
       const newTodo = parseTodoData(createdEvent);
       setTodoItems(prev => [...prev, newTodo]);
     } catch (error: any) {
@@ -440,13 +377,9 @@ function MatrixPageContent() {
     setDraggedItem(null);
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
+      const accessToken = await acquireToken();
 
-      await updateTodoItem(response.accessToken, bookId, draggedItem.id, {
+      await updateTodoItem(accessToken, bookId, draggedItem.id, {
         urgent,
         important,
       });
@@ -505,13 +438,9 @@ function MatrixPageContent() {
     );
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
+      const accessToken = await acquireToken();
 
-      await updateTodoItem(response.accessToken, bookId, todo.id, {
+      await updateTodoItem(accessToken, bookId, todo.id, {
         status: newStatus,
       });
     } catch (error: any) {
@@ -534,13 +463,9 @@ function MatrixPageContent() {
     setSelectedTodo(prev => prev ? { ...prev, ...updatedFields } : prev);
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({
-        ...loginRequest,
-        account: account,
-      });
+      const accessToken = await acquireToken();
 
-      await updateTodoItem(response.accessToken, bookId, selectedTodo.id, updatedFields);
+      await updateTodoItem(accessToken, bookId, selectedTodo.id, updatedFields);
     } catch (error: any) {
       console.error('Error updating TODO:', error);
       setTodoItems(previousItems);
@@ -572,15 +497,14 @@ function MatrixPageContent() {
     updateFilterState();
 
     try {
-      const account = accounts[0];
-      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
+      const accessToken = await acquireToken();
       const CONCURRENCY = 5;
       let idx = 0;
       const worker = async () => {
         while (idx < affectedItems.length) {
           const item = affectedItems[idx++];
           if (!item.id) continue;
-          await updateTodoItem(response.accessToken, bookId, item.id, {
+          await updateTodoItem(accessToken, bookId, item.id, {
             categories: computeNewCategories(item),
           });
         }
@@ -634,7 +558,7 @@ function MatrixPageContent() {
 
   const handleLogin = async () => {
     try {
-      await instance.loginPopup(loginRequest);
+      await graphLogin();
     } catch (error) {
       console.error('Login failed:', error);
       setError('Login failed. Please try again.');
@@ -706,10 +630,10 @@ function MatrixPageContent() {
             </div>
           </div>
 
-          {error && (
+          {displayError && (
             <div className={styles.error} role="alert">
               <span className={styles.errorTitle}>Error: </span>
-              <span>{error}</span>
+              <span>{displayError}</span>
             </div>
           )}
 

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -183,8 +183,8 @@ export default function MatrixPage() {
 }
 
 function MatrixPageContent() {
-  const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin, instance } = useGraphToken();
-  const { bookId, calendars, currentCalendarName, handleCalendarSwitch, error: calendarError, setError: setCalendarError } = useBookId('/matrix');
+  const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin } = useGraphToken();
+  const { bookId, calendars, currentCalendarName, handleCalendarSwitch, error: calendarError } = useBookId('/matrix');
   const bookIdRef = useRef(bookId);
   const sweepAttemptedRef = useRef(false);
   bookIdRef.current = bookId;

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -18,6 +18,7 @@ const BASE_NAV_ITEMS: NavItem[] = [
   { href: '/', label: 'Home', icon: '🏠' },
   { href: '/books', label: 'My Books', icon: '📚' },
   { href: '/matrix', label: 'Matrix', icon: '📊', matchPrefix: true },
+  { href: '/cancelled', label: 'Cancelled Tasks', icon: '🗑️', matchPrefix: true },
 ];
 
 export default function HamburgerMenu() {

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -93,7 +93,8 @@ export default function HamburgerMenu() {
 
   function isActive(item: NavItem): boolean {
     if (item.matchPrefix) {
-      return pathname.startsWith('/matrix');
+      const basePath = item.href.split('?')[0];
+      return pathname.startsWith(basePath);
     }
     return pathname === item.href;
   }

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -41,7 +41,7 @@ export default function HamburgerMenu() {
     const savedBookId = getLastBookId();
     if (savedBookId) {
       setNavItems(BASE_NAV_ITEMS.map(item =>
-        item.matchPrefix ? { ...item, href: `/matrix?bookId=${encodeURIComponent(savedBookId)}` } : item
+        item.matchPrefix ? { ...item, href: `${item.href}?bookId=${encodeURIComponent(savedBookId)}` } : item
       ));
     } else {
       setNavItems(BASE_NAV_ITEMS);

--- a/src/arrange-v4/lib/graphService.ts
+++ b/src/arrange-v4/lib/graphService.ts
@@ -188,3 +188,36 @@ export async function getCalendarEvents(
     throw error;
   }
 }
+
+/**
+ * Fetches ALL events from a calendar (no date range filter).
+ * Uses the /events endpoint instead of /calendarView so that
+ * items whose dates fall outside a sliding window are still returned.
+ */
+export async function getAllCalendarEvents(
+  accessToken: string,
+  calendarId: string
+): Promise<CalendarEvent[]> {
+  const client = createGraphClient(accessToken);
+  const allEvents: CalendarEvent[] = [];
+
+  try {
+    let response = await client
+      .api(`/me/calendars/${calendarId}/events`)
+      .top(100)
+      .select('id,createdDateTime,lastModifiedDateTime,categories,subject,body,start,end')
+      .get();
+
+    allEvents.push(...(response.value || []));
+
+    while (response['@odata.nextLink']) {
+      response = await client.api(response['@odata.nextLink']).get();
+      allEvents.push(...(response.value || []));
+    }
+
+    return allEvents;
+  } catch (error) {
+    console.error('Error fetching all calendar events:', error);
+    throw error;
+  }
+}

--- a/src/arrange-v4/lib/hooks/useBookId.ts
+++ b/src/arrange-v4/lib/hooks/useBookId.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { getCalendars, Calendar } from '@/lib/graphService';
+import { filterArrangeCalendars, getCalendarDisplayName } from '@/lib/calendarUtils';
+import { getLastBookId, setLastBookId, clearLastBookId } from '@/lib/bookStorage';
+import { useGraphToken } from './useGraphToken';
+
+/**
+ * Shared hook for resolving the selected book (calendar).
+ * Reads bookId from search params, falls back to localStorage,
+ * fetches arrange calendars, validates the bookId, and provides
+ * a book-switcher helper.
+ *
+ * @param routePrefix  The route path prefix for this page (e.g. '/matrix', '/cancelled').
+ *                     Used to build redirect URLs with the bookId query param.
+ */
+export function useBookId(routePrefix: string) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const bookId = searchParams.get('bookId');
+
+  const { acquireToken, isAuthenticated } = useGraphToken();
+
+  const [calendars, setCalendars] = useState<Calendar[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Redirect to saved book if no bookId in URL
+  useEffect(() => {
+    if (!bookId) {
+      const saved = getLastBookId();
+      if (saved) {
+        router.replace(`${routePrefix}?bookId=${encodeURIComponent(saved)}`);
+      }
+    }
+  }, [bookId, router, routePrefix]);
+
+  // Fetch calendars and validate bookId
+  const fetchCalendars = useCallback(async () => {
+    if (!isAuthenticated) return;
+    try {
+      const accessToken = await acquireToken();
+      const all = await getCalendars(accessToken);
+      const arrangeCalendars = filterArrangeCalendars(all);
+      setCalendars(arrangeCalendars);
+
+      if (bookId && !arrangeCalendars.some(c => c.id === bookId)) {
+        clearLastBookId();
+        router.replace('/books');
+      } else if (bookId) {
+        setLastBookId(bookId);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch calendars';
+      console.error('Error fetching calendars:', err);
+      setError(message);
+    }
+  }, [isAuthenticated, acquireToken, bookId, router]);
+
+  useEffect(() => {
+    fetchCalendars(); // eslint-disable-line react-hooks/set-state-in-effect -- async data fetching sets state after await
+  }, [fetchCalendars]);
+
+  const handleCalendarSwitch = useCallback((calendarId: string) => {
+    router.push(`${routePrefix}?bookId=${encodeURIComponent(calendarId)}`);
+  }, [router, routePrefix]);
+
+  const currentCalendar = calendars.find(c => c.id === bookId);
+  const currentCalendarName = currentCalendar ? getCalendarDisplayName(currentCalendar) : bookId;
+
+  return {
+    bookId,
+    calendars,
+    currentCalendarName,
+    handleCalendarSwitch,
+    fetchCalendars,
+    error,
+    setError,
+  };
+}

--- a/src/arrange-v4/lib/hooks/useBookId.ts
+++ b/src/arrange-v4/lib/hooks/useBookId.ts
@@ -39,6 +39,7 @@ export function useBookId(routePrefix: string) {
   // Fetch calendars and validate bookId
   const fetchCalendars = useCallback(async () => {
     if (!isAuthenticated) return;
+    setError(null);
     try {
       const accessToken = await acquireToken();
       const all = await getCalendars(accessToken);

--- a/src/arrange-v4/lib/hooks/useBookId.ts
+++ b/src/arrange-v4/lib/hooks/useBookId.ts
@@ -21,7 +21,7 @@ export function useBookId(routePrefix: string) {
   const router = useRouter();
   const bookId = searchParams.get('bookId');
 
-  const { acquireToken, isAuthenticated } = useGraphToken();
+  const { acquireToken, isAuthenticated, inProgress } = useGraphToken();
 
   const [calendars, setCalendars] = useState<Calendar[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -38,7 +38,7 @@ export function useBookId(routePrefix: string) {
 
   // Fetch calendars and validate bookId
   const fetchCalendars = useCallback(async () => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || inProgress !== 'none') return;
     setError(null);
     try {
       const accessToken = await acquireToken();
@@ -57,7 +57,7 @@ export function useBookId(routePrefix: string) {
       console.error('Error fetching calendars:', err);
       setError(message);
     }
-  }, [isAuthenticated, acquireToken, bookId, router]);
+  }, [isAuthenticated, inProgress, acquireToken, bookId, router]);
 
   useEffect(() => {
     fetchCalendars(); // eslint-disable-line react-hooks/set-state-in-effect -- async data fetching sets state after await

--- a/src/arrange-v4/lib/hooks/useGraphToken.ts
+++ b/src/arrange-v4/lib/hooks/useGraphToken.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useMsal } from '@azure/msal-react';
+import { loginRequest } from '@/lib/msalConfig';
+
+/**
+ * Shared hook for acquiring a Microsoft Graph API access token.
+ * Wraps the acquireTokenSilent + acquireTokenPopup fallback pattern
+ * that is used across multiple pages.
+ */
+export function useGraphToken() {
+  const { instance, accounts, inProgress } = useMsal();
+  const isAuthenticated = accounts.length > 0;
+
+  const acquireToken = useCallback(async (): Promise<string> => {
+    const account = accounts[0];
+    try {
+      const response = await instance.acquireTokenSilent({ ...loginRequest, account });
+      return response.accessToken;
+    } catch (silentError: unknown) {
+      if (silentError instanceof Error && silentError.name === 'InteractionRequiredAuthError') {
+        const response = await instance.acquireTokenPopup(loginRequest);
+        return response.accessToken;
+      }
+      throw silentError;
+    }
+  }, [instance, accounts]);
+
+  const handleLogin = useCallback(async () => {
+    await instance.loginPopup(loginRequest);
+  }, [instance]);
+
+  return { acquireToken, isAuthenticated, inProgress, handleLogin, instance };
+}

--- a/src/arrange-v4/lib/hooks/useGraphToken.ts
+++ b/src/arrange-v4/lib/hooks/useGraphToken.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from 'react';
 import { useMsal } from '@azure/msal-react';
+import { InteractionRequiredAuthError } from '@azure/msal-browser';
 import { loginRequest } from '@/lib/msalConfig';
 
 /**
@@ -15,11 +16,14 @@ export function useGraphToken() {
 
   const acquireToken = useCallback(async (): Promise<string> => {
     const account = accounts[0];
+    if (!account) {
+      throw new Error('No signed-in Microsoft account is available. Sign in before requesting a Microsoft Graph access token.');
+    }
     try {
       const response = await instance.acquireTokenSilent({ ...loginRequest, account });
       return response.accessToken;
     } catch (silentError: unknown) {
-      if (silentError instanceof Error && silentError.name === 'InteractionRequiredAuthError') {
+      if (silentError instanceof InteractionRequiredAuthError) {
         const response = await instance.acquireTokenPopup(loginRequest);
         return response.accessToken;
       }


### PR DESCRIPTION
## Summary

Adds a dedicated **Cancelled Tasks** page where users can review, multi-select, and bulk-delete cancelled tasks.

Closes #14

## What's New

- **`/cancelled` page** — lists all cancelled tasks with checkboxes, select-all, bulk delete with confirmation dialog, optimistic UI with rollback, and concurrent deletion (5 workers)
- **Read-only detail view** — click any task row to inspect full details via the existing `ViewTodoItem` component (no editing)
- **`getAllCalendarEvents()`** in `graphService.ts` — uses the `/events` endpoint (no date range) so old cancelled items that fell outside the ±30-day calendar view window are still found
- **Navigation** — 🗑️ Cancelled Tasks entry in the hamburger menu

## DRY Refactoring

- Extracted **`useGraphToken`** hook — shared token acquisition (`acquireTokenSilent` + popup fallback) used by 3 pages
- Extracted **`useBookId`** hook — shared book selection (search params → localStorage fallback → calendar fetching → validation)
- Refactored `matrix/page.tsx` (−71 lines) and `books/page.tsx` (−30 lines) to use these hooks

## Files Changed (9 total, 5 new)

| File | Change |
|---|---|
| `lib/hooks/useGraphToken.ts` | **New** — shared auth hook |
| `lib/hooks/useBookId.ts` | **New** — shared book selection hook |
| `lib/graphService.ts` | Added `getAllCalendarEvents()` |
| `app/cancelled/page.tsx` | **New** — cancelled tasks page |
| `app/cancelled/page.module.css` | **New** — styles |
| `components/HamburgerMenu.tsx` | Added nav entry + fixed `matchPrefix` href/active bugs |
| `app/matrix/page.tsx` | Refactored to shared hooks |
| `app/books/page.tsx` | Refactored to shared hooks |
| `devnotes/BugNotes.md` | **New** — documents HamburgerMenu hardcoded-path lessons |

## Testing

- ✅ `npm run build` passes
- ✅ Lint errors reduced (27 → 23)
- ✅ Dev server verified