### PR TITLE
fix: Tab headers truncated on mobile + ESC to close modals (#39, #36)

### DIFF
--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -35,6 +35,13 @@
   }
 }
 
+@media (max-width: 480px) {
+  .tab {
+    padding: 8px 12px;
+    font-size: 0.8rem;
+  }
+}
+
 .title {
   font-size: 1.25rem;
   font-weight: bold;
@@ -382,6 +389,8 @@
   border-bottom: 2px solid #e5e7eb;
   margin-bottom: 16px;
   flex-shrink: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .tab {
@@ -396,6 +405,7 @@
   cursor: pointer;
   transition: all 0.15s;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tab:hover {

--- a/src/arrange-v4/components/AddTodoItem.module.css
+++ b/src/arrange-v4/components/AddTodoItem.module.css
@@ -35,13 +35,6 @@
   }
 }
 
-@media (max-width: 480px) {
-  .tab {
-    padding: 8px 12px;
-    font-size: 0.8rem;
-  }
-}
-
 .title {
   font-size: 1.25rem;
   font-weight: bold;
@@ -416,6 +409,13 @@
 .tabActive {
   color: #2563eb;
   border-bottom-color: #2563eb;
+}
+
+@media (max-width: 480px) {
+  .tab {
+    padding: 8px 12px;
+    font-size: 0.8rem;
+  }
 }
 
 .tabContent {

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { TodoItem, TodoStatus } from '@/lib/todoDataService';
 import ChecklistEditor from './ChecklistEditor';
 import TagPicker from './TagPicker';
@@ -111,6 +111,15 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
     resetForm();
     setIsOpen(false);
   };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isSubmitting) handleCancel();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, isSubmitting]);
 
   if (!isOpen) {
     return (

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -115,7 +115,9 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
   useEffect(() => {
     if (!isOpen) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isSubmitting) handleCancel();
+      if (e.key === 'Escape' && !isSubmitting) {
+        setIsOpen(false);
+      }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -16,22 +16,22 @@ interface AddTodoItemProps {
   availableCategories?: string[];
 }
 
+// Helper function to format datetime for input (accepts optional hours offset)
+function getDateTimeString(hoursOffset: number = 0) {
+  const now = new Date();
+  now.setHours(now.getHours() + hoursOffset);
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
 export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false, defaultImportant = false, buttonText = 'Add TODO', compact = false, availableCategories = [] }: AddTodoItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Helper function to format datetime for input (accepts optional hours offset)
-  const getDateTimeString = (hoursOffset: number = 0) => {
-    const now = new Date();
-    now.setHours(now.getHours() + hoursOffset);
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const hours = String(now.getHours()).padStart(2, '0');
-    const minutes = String(now.getMinutes()).padStart(2, '0');
-    return `${year}-${month}-${day}T${hours}:${minutes}`;
-  };
 
   // Form state
   const [subject, setSubject] = useState('');

--- a/src/arrange-v4/components/AddTodoItem.tsx
+++ b/src/arrange-v4/components/AddTodoItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { TodoItem, TodoStatus } from '@/lib/todoDataService';
 import ChecklistEditor from './ChecklistEditor';
 import TagPicker from './TagPicker';
@@ -46,7 +46,7 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
   type AddTab = 'essentials' | 'tags' | 'remarks' | 'checklist';
   const [activeTab, setActiveTab] = useState<AddTab>('essentials');
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     setSubject('');
     setUrgent(defaultUrgent);
     setImportant(defaultImportant);
@@ -58,7 +58,7 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
     setCategories([]);
     setActiveTab('essentials');
     setError(null);
-  };
+  }, [defaultUrgent, defaultImportant]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -116,12 +116,13 @@ export default function AddTodoItem({ onAddTodo, disabled, defaultUrgent = false
     if (!isOpen) return;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && !isSubmitting) {
+        resetForm();
         setIsOpen(false);
       }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, [isOpen, isSubmitting]);
+  }, [isOpen, isSubmitting, resetForm]);
 
   if (!isOpen) {
     return (

--- a/src/arrange-v4/components/CreateCalendar.tsx
+++ b/src/arrange-v4/components/CreateCalendar.tsx
@@ -52,7 +52,11 @@ export default function CreateCalendar({ onCreateCalendar, disabled = false }: C
   useEffect(() => {
     if (!isOpen) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isCreating) handleCancel();
+      if (e.key === 'Escape' && !isCreating) {
+        setIsOpen(false);
+        setCalendarName('');
+        setError(null);
+      }
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);

--- a/src/arrange-v4/components/CreateCalendar.tsx
+++ b/src/arrange-v4/components/CreateCalendar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styles from './CreateCalendar.module.css';
 
 interface CreateCalendarProps {
@@ -48,6 +48,15 @@ export default function CreateCalendar({ onCreateCalendar, disabled = false }: C
     setCalendarName('');
     setError(null);
   };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isCreating) handleCancel();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, isCreating]);
 
   return (
     <>

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { TodoItem } from '@/lib/todoDataService';
 import styles from './ManageTags.module.css';
 
@@ -37,6 +37,14 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
   const handleClose = () => {
     if (!busy) onClose();
   };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClose();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [busy, onClose]);
 
   const clearActions = () => {
     setRenamingTag(null);

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -40,7 +40,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') handleClose();
+      if (e.key === 'Escape' && !busy) onClose();
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);

--- a/src/arrange-v4/components/ManageTags.tsx
+++ b/src/arrange-v4/components/ManageTags.tsx
@@ -40,7 +40,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !busy) onClose();
+      if (e.key === 'Escape' && !e.defaultPrevented && !busy) onClose();
     };
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
@@ -147,7 +147,7 @@ export default function ManageTags({ tags, todoItems, onRenameTag, onDeleteTag, 
                     onChange={(e) => setRenameValue(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') handleRename();
-                      if (e.key === 'Escape') setRenamingTag(null);
+                      if (e.key === 'Escape') { e.preventDefault(); setRenamingTag(null); }
                     }}
                     disabled={busy}
                     autoFocus

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -99,7 +99,7 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
     }
   };
 
-  const handleCancelEdit = () => {
+  const handleCancelEdit = useCallback(() => {
     setSubject(todo.subject);
     setUrgent(todo.urgent ?? false);
     setImportant(todo.important ?? false);
@@ -111,17 +111,16 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
     setCategories(todo.categories || []);
     setError(null);
     setEditing(false);
-  };
+  }, [todo]);
 
   const handleEsc = useCallback((e: KeyboardEvent) => {
     if (e.key !== 'Escape') return;
     if (editing && !isSubmitting) {
-      setEditing(false);
-      setError(null);
+      handleCancelEdit();
     } else if (!editing) {
       onClose();
     }
-  }, [editing, isSubmitting, onClose]);
+  }, [editing, isSubmitting, onClose, handleCancelEdit]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleEsc);

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -15,6 +15,13 @@ interface ViewTodoItemProps {
 
 type ViewTab = 'essentials' | 'tags' | 'remarks' | 'checklist';
 
+function formatLocalDateTime(isoString?: string) {
+  if (!isoString) return '';
+  const d = new Date(isoString);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategories = [] }: ViewTodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -29,13 +36,6 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
   useEffect(() => {
     setViewChecklist(null);
   }, [todo.id]);
-
-  const formatLocalDateTime = (isoString?: string) => {
-    if (!isoString) return '';
-    const d = new Date(isoString);
-    const pad = (n: number) => String(n).padStart(2, '0');
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  };
 
   // Edit form state
   const [subject, setSubject] = useState(todo.subject);

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { TodoItem, TodoStatus, STATUS_LABELS } from '@/lib/todoDataService';
 import ChecklistEditor from './ChecklistEditor';
 import TagPicker from './TagPicker';
@@ -112,6 +112,20 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
     setError(null);
     setEditing(false);
   };
+
+  const handleEsc = useCallback((e: KeyboardEvent) => {
+    if (e.key !== 'Escape') return;
+    if (editing && !isSubmitting) {
+      handleCancelEdit();
+    } else if (!editing) {
+      onClose();
+    }
+  }, [editing, isSubmitting, onClose]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [handleEsc]);
 
   if (editing) {
     return (

--- a/src/arrange-v4/components/ViewTodoItem.tsx
+++ b/src/arrange-v4/components/ViewTodoItem.tsx
@@ -116,7 +116,8 @@ export default function ViewTodoItem({ todo, onClose, onUpdate, availableCategor
   const handleEsc = useCallback((e: KeyboardEvent) => {
     if (e.key !== 'Escape') return;
     if (editing && !isSubmitting) {
-      handleCancelEdit();
+      setEditing(false);
+      setError(null);
     } else if (!editing) {
       onClose();
     }


### PR DESCRIPTION
## Summary

Fixes two UX issues with modals.

Closes #39
Closes #36

### Tab headers truncated on mobile (#39)
The tab bar (Essentials, Tags, Remarks, Checklist) was clipped on narrow screens because tabs had `white-space: nowrap` with no overflow handling.

**Fix:**
- Tab bar now has `overflow-x: auto` for horizontal scrolling
- Tabs get `flex-shrink: 0` so they maintain their natural width
- Mobile breakpoint (≤480px) reduces tab padding and font size

### ESC to close/cancel modals (#36)
No modal in the app responded to the Escape key.

**Fix — all 4 modal components now handle ESC:**
- **AddTodoItem**: ESC cancels and resets form (blocked while submitting)
- **ViewTodoItem**: ESC cancels edit mode first, closes on second press
- **CreateCalendar**: ESC cancels and resets form (blocked while creating)
- **ManageTags**: ESC closes dialog (blocked while busy)

## Files Changed

| File | Change |
|---|---|
| `components/AddTodoItem.module.css` | Scrollable tab bar + mobile breakpoint |
| `components/AddTodoItem.tsx` | ESC key handler |
| `components/ViewTodoItem.tsx` | ESC key handler (edit → view → close) |
| `components/CreateCalendar.tsx` | ESC key handler |
| `components/ManageTags.tsx` | ESC key handler |

## Testing
- ✅ `npm run build` passes