### PR TITLE
feat: Add Scrum Board view with drag-and-drop status lanes (#25)

### DIFF
--- a/src/arrange-v4/app/scrum/page.module.css
+++ b/src/arrange-v4/app/scrum/page.module.css
@@ -1,0 +1,360 @@
+.container {
+  min-height: 100vh;
+  background-color: #f9fafb;
+}
+
+.inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 32px 16px;
+}
+
+.card {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-size: 1.875rem;
+  font-weight: bold;
+  color: #111827;
+}
+
+.subtitle {
+  color: #4b5563;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.button {
+  font-weight: 500;
+  padding: 8px 24px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.875rem;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.buttonPrimary {
+  background-color: #2563eb;
+  color: white;
+}
+
+.buttonPrimary:hover:not(:disabled) {
+  background-color: #1d4ed8;
+}
+
+.buttonSecondary {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.buttonSecondary:hover:not(:disabled) {
+  background-color: #d1d5db;
+}
+
+.bookSwitcher {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #374151;
+  background-color: white;
+  cursor: pointer;
+}
+
+/* Error / loading */
+.error {
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-bottom: 16px;
+}
+
+.errorTitle {
+  font-weight: bold;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 32px;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid #e5e7eb;
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Warning (no book) */
+.warning {
+  background-color: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  padding: 16px 24px;
+  border-radius: 8px;
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.warningLink {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+/* Board section */
+.boardSection {
+  margin-top: 0;
+}
+
+.boardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.boardHeaderActions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.filterCount {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.filterToggle {
+  font-size: 0.8rem;
+  padding: 4px 12px;
+}
+
+/* Tag bar */
+.tagBar {
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  padding: 10px 16px;
+  margin-bottom: 16px;
+}
+
+.categoryFilterChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.categoryFilterChip {
+  font-size: 0.8rem;
+  padding: 4px 12px;
+  border-radius: 16px;
+  border: 1px solid #d1d5db;
+  background-color: white;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.categoryFilterChip:hover {
+  border-color: #2563eb;
+}
+
+.categoryFilterChipActive {
+  background-color: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+
+.categoryFilterClear {
+  border-color: #fca5a5;
+  color: #dc2626;
+}
+
+.categoryFilterClear:hover {
+  background-color: #fef2f2;
+}
+
+/* Swimming lanes */
+.board {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .board {
+    grid-template-columns: repeat(4, 1fr);
+    height: calc(100vh - 280px);
+  }
+}
+
+.lane {
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+  overflow: hidden;
+  border: 2px solid transparent;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+@media (min-width: 768px) {
+  .lane {
+    min-height: 0;
+    max-height: 100%;
+  }
+}
+
+/* Lane colors */
+.laneNew {
+  background-color: #f9fafb;
+  border-color: #e5e7eb;
+}
+
+.laneInProgress {
+  background-color: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.laneBlocked {
+  background-color: #fef2f2;
+  border-color: #fecaca;
+}
+
+.laneFinished {
+  background-color: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+/* Drop zone */
+.laneDropZone {
+  border: 3px dashed currentColor;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.laneNew.laneDropZone {
+  border-color: #6b7280;
+}
+
+.laneInProgress.laneDropZone {
+  border-color: #2563eb;
+}
+
+.laneBlocked.laneDropZone {
+  border-color: #dc2626;
+}
+
+.laneFinished.laneDropZone {
+  border-color: #16a34a;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* Lane header */
+.laneHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.laneTitle {
+  font-size: 0.9rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.laneTitleNew { color: #6b7280; }
+.laneTitleInProgress { color: #2563eb; }
+.laneTitleBlocked { color: #dc2626; }
+.laneTitleFinished { color: #16a34a; }
+
+.laneCount {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background-color: rgba(0, 0, 0, 0.08);
+  color: #374151;
+}
+
+/* Lane content */
+.laneContent {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+}
+
+.laneEmpty {
+  text-align: center;
+  padding: 24px 8px;
+  color: #9ca3af;
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .actions {
+    flex-wrap: wrap;
+  }
+
+  .inner {
+    padding: 16px;
+  }
+}

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -13,9 +13,10 @@ import ScrumCard from '@/components/ScrumCard';
 import Link from 'next/link';
 import styles from './page.module.css';
 
-const LANE_STATUSES: TodoStatus[] = ['new', 'blocked', 'inProgress', 'finished'];
+const LANE_STATUSES = ['new', 'blocked', 'inProgress', 'finished'] as const satisfies readonly TodoStatus[];
+type LaneStatus = (typeof LANE_STATUSES)[number];
 
-const LANE_STYLES: Record<string, { lane: string; title: string }> = {
+const LANE_STYLES: Record<LaneStatus, { lane: string; title: string }> = {
   new: { lane: styles.laneNew, title: styles.laneTitleNew },
   inProgress: { lane: styles.laneInProgress, title: styles.laneTitleInProgress },
   blocked: { lane: styles.laneBlocked, title: styles.laneTitleBlocked },
@@ -65,7 +66,7 @@ function ScrumPageContent() {
   const filteredItems = useMemo(() => {
     return todoItems.filter(todo => {
       const status = todo.status || 'new';
-      if (!LANE_STATUSES.includes(status)) return false;
+      if (!(LANE_STATUSES as readonly string[]).includes(status)) return false;
 
       if (categoryFilterActive) {
         const hasCats = todo.categories && todo.categories.length > 0;

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -461,6 +461,7 @@ function ScrumPageContent() {
                           key={todo.id}
                           todo={todo}
                           onDragStart={handleDragStart}
+                          onDragEnd={() => setDraggedItem(null)}
                           onClick={setSelectedTodo}
                         />
                       ))}

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -13,7 +13,7 @@ import ScrumCard from '@/components/ScrumCard';
 import Link from 'next/link';
 import styles from './page.module.css';
 
-const LANE_STATUSES: TodoStatus[] = ['new', 'inProgress', 'blocked', 'finished'];
+const LANE_STATUSES: TodoStatus[] = ['new', 'blocked', 'inProgress', 'finished'];
 
 const LANE_STYLES: Record<string, { lane: string; title: string }> = {
   new: { lane: styles.laneNew, title: styles.laneTitleNew },

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -1,0 +1,514 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
+import { getCalendarEvents } from '@/lib/graphService';
+import { createTodoItem, updateTodoItem, TodoItem, parseTodoData, TodoStatus, STATUS_LABELS } from '@/lib/todoDataService';
+import { getCalendarDisplayName } from '@/lib/calendarUtils';
+import { useGraphToken } from '@/lib/hooks/useGraphToken';
+import { useBookId } from '@/lib/hooks/useBookId';
+import AddTodoItem from '@/components/AddTodoItem';
+import ViewTodoItem from '@/components/ViewTodoItem';
+import ManageTags from '@/components/ManageTags';
+import ScrumCard from '@/components/ScrumCard';
+import Link from 'next/link';
+import styles from './page.module.css';
+
+const LANE_STATUSES: TodoStatus[] = ['new', 'inProgress', 'blocked', 'finished'];
+
+const LANE_STYLES: Record<string, { lane: string; title: string }> = {
+  new: { lane: styles.laneNew, title: styles.laneTitleNew },
+  inProgress: { lane: styles.laneInProgress, title: styles.laneTitleInProgress },
+  blocked: { lane: styles.laneBlocked, title: styles.laneTitleBlocked },
+  finished: { lane: styles.laneFinished, title: styles.laneTitleFinished },
+};
+
+function sortByPriority(items: (TodoItem & { id?: string })[]) {
+  return [...items].sort((a, b) => {
+    const ai = a.important ? 1 : 0;
+    const bi = b.important ? 1 : 0;
+    if (bi !== ai) return bi - ai;
+    const au = a.urgent ? 1 : 0;
+    const bu = b.urgent ? 1 : 0;
+    if (bu !== au) return bu - au;
+    return (a.subject || '').localeCompare(b.subject || '');
+  });
+}
+
+function ScrumPageContent() {
+  const { acquireToken, isAuthenticated, inProgress, handleLogin: graphLogin } = useGraphToken();
+  const { bookId, calendars, currentCalendarName, handleCalendarSwitch, error: calendarError } = useBookId('/scrum');
+
+  const [todoItems, setTodoItems] = useState<(TodoItem & { id?: string })[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draggedItem, setDraggedItem] = useState<(TodoItem & { id?: string }) | null>(null);
+  const [selectedTodo, setSelectedTodo] = useState<(TodoItem & { id?: string }) | null>(null);
+  const [showTags, setShowTags] = useState(true);
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
+  const [showUncategorized, setShowUncategorized] = useState(false);
+  const [showManageTags, setShowManageTags] = useState(false);
+
+  const displayError = error || calendarError;
+
+  const allCategories = useMemo(() => {
+    const cats = new Set<string>();
+    for (const todo of todoItems) {
+      if (todo.categories) {
+        for (const c of todo.categories) cats.add(c);
+      }
+    }
+    return Array.from(cats).sort((a, b) => a.localeCompare(b));
+  }, [todoItems]);
+
+  const categoryFilterActive = selectedCategories.size > 0 || showUncategorized;
+
+  const filteredItems = useMemo(() => {
+    return todoItems.filter(todo => {
+      const status = todo.status || 'new';
+      if (!LANE_STATUSES.includes(status)) return false;
+
+      if (categoryFilterActive) {
+        const hasCats = todo.categories && todo.categories.length > 0;
+        if (showUncategorized && !hasCats) return true;
+        if (hasCats && todo.categories!.some(c => selectedCategories.has(c))) return true;
+        return false;
+      }
+      return true;
+    });
+  }, [todoItems, selectedCategories, showUncategorized, categoryFilterActive]);
+
+  const lanes = useMemo(() => {
+    const result: Record<string, (TodoItem & { id?: string })[]> = {};
+    for (const status of LANE_STATUSES) {
+      result[status] = sortByPriority(filteredItems.filter(t => (t.status || 'new') === status));
+    }
+    return result;
+  }, [filteredItems]);
+
+  const fetchEvents = useCallback(async () => {
+    if (!isAuthenticated || !bookId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const accessToken = await acquireToken();
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const startDate = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const endDate = new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+      const eventsData = await getCalendarEvents(
+        accessToken, bookId,
+        startDate.toISOString(), endDate.toISOString()
+      );
+      setTodoItems(eventsData.map(event => parseTodoData(event)));
+    } catch (err: unknown) {
+      console.error('Error fetching events:', err);
+      const message = err instanceof Error ? err.message : 'Failed to fetch events';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [isAuthenticated, bookId, acquireToken]);
+
+  useEffect(() => {
+    if (isAuthenticated && inProgress === 'none' && bookId) {
+      fetchEvents();
+    }
+  }, [isAuthenticated, inProgress, bookId, fetchEvents]);
+
+  const handleAddTodo = async (todoItem: TodoItem) => {
+    if (!bookId) throw new Error('No book selected');
+    try {
+      const accessToken = await acquireToken();
+      const createdEvent = await createTodoItem(accessToken, bookId, todoItem);
+      const newTodo = parseTodoData(createdEvent);
+      setTodoItems(prev => [...prev, newTodo]);
+    } catch (err: unknown) {
+      console.error('Error creating TODO item:', err);
+      const message = err instanceof Error ? err.message : 'Failed to create TODO item';
+      throw new Error(message);
+    }
+  };
+
+  const handleDragStart = (todo: TodoItem & { id?: string }) => {
+    setDraggedItem(todo);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = async (newStatus: TodoStatus) => {
+    if (!draggedItem || !draggedItem.id || !bookId) return;
+
+    const currentStatus = draggedItem.status || 'new';
+    if (currentStatus === newStatus) {
+      setDraggedItem(null);
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const updatedTimestamps: Partial<TodoItem> = {};
+
+    if (newStatus === 'inProgress' && !draggedItem.startDateTime) {
+      updatedTimestamps.startDateTime = now;
+    }
+    if (newStatus === 'new') {
+      updatedTimestamps.startDateTime = undefined;
+    }
+    if (newStatus === 'finished') {
+      if (!draggedItem.startDateTime) updatedTimestamps.startDateTime = now;
+      if (!draggedItem.finishDateTime) updatedTimestamps.finishDateTime = now;
+    }
+    if (newStatus !== 'finished' && currentStatus === 'finished') {
+      updatedTimestamps.finishDateTime = undefined;
+    }
+
+    const previousItems = [...todoItems];
+    setTodoItems(items =>
+      items.map(item =>
+        item.id === draggedItem.id
+          ? { ...item, status: newStatus, ...updatedTimestamps }
+          : item
+      )
+    );
+    setDraggedItem(null);
+
+    try {
+      const accessToken = await acquireToken();
+      await updateTodoItem(accessToken, bookId, draggedItem.id, { status: newStatus });
+    } catch (err: unknown) {
+      console.error('Error updating TODO status:', err);
+      setTodoItems(previousItems);
+      setError(err instanceof Error ? err.message : 'Failed to update status');
+    }
+  };
+
+  const handleUpdateTodo = async (updatedFields: Partial<TodoItem>) => {
+    if (!selectedTodo?.id || !bookId) return;
+
+    const previousItems = [...todoItems];
+    setTodoItems(items =>
+      items.map(item =>
+        item.id === selectedTodo.id ? { ...item, ...updatedFields } : item
+      )
+    );
+    setSelectedTodo(prev => prev ? { ...prev, ...updatedFields } : prev);
+
+    try {
+      const accessToken = await acquireToken();
+      await updateTodoItem(accessToken, bookId, selectedTodo.id, updatedFields);
+    } catch (err: unknown) {
+      console.error('Error updating TODO:', err);
+      setTodoItems(previousItems);
+      const reverted = previousItems.find(i => i.id === selectedTodo.id);
+      if (reverted) setSelectedTodo(reverted);
+      throw err;
+    }
+  };
+
+  const bulkUpdateCategories = async (
+    affectedItems: (TodoItem & { id?: string })[],
+    computeNewCategories: (item: TodoItem & { id?: string }) => string[],
+    updateFilterState: () => void,
+  ) => {
+    if (!bookId || affectedItems.length === 0) return;
+
+    const previousItems = [...todoItems];
+    const previousSelectedCategories = new Set(selectedCategories);
+    const previousShowUncategorized = showUncategorized;
+    const affectedIds = new Set(affectedItems.filter(a => a.id).map(a => a.id));
+
+    setTodoItems(items =>
+      items.map(item =>
+        affectedIds.has(item.id)
+          ? { ...item, categories: computeNewCategories(item) }
+          : item
+      )
+    );
+    updateFilterState();
+
+    try {
+      const accessToken = await acquireToken();
+      const CONCURRENCY = 5;
+      let idx = 0;
+      const worker = async () => {
+        while (idx < affectedItems.length) {
+          const item = affectedItems[idx++];
+          if (!item.id) continue;
+          await updateTodoItem(accessToken, bookId, item.id, {
+            categories: computeNewCategories(item),
+          });
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, affectedItems.length) }, () => worker()));
+    } catch (err: unknown) {
+      console.error('Error updating tags:', err);
+      setTodoItems(previousItems);
+      setSelectedCategories(previousSelectedCategories);
+      setShowUncategorized(previousShowUncategorized);
+      throw err;
+    }
+  };
+
+  const handleDeleteTag = async (tag: string) => {
+    const affected = todoItems.filter(item => item.categories?.includes(tag));
+    await bulkUpdateCategories(
+      affected,
+      (item) => (item.categories || []).filter(c => c !== tag),
+      () => setSelectedCategories(prev => { const next = new Set(prev); next.delete(tag); return next; }),
+    );
+  };
+
+  const handleRenameTag = async (oldTag: string, newTag: string) => {
+    const affected = todoItems.filter(item => item.categories?.includes(oldTag));
+    await bulkUpdateCategories(
+      affected,
+      (item) => (item.categories || []).map(c => c === oldTag ? newTag : c),
+      () => setSelectedCategories(prev => {
+        if (!prev.has(oldTag)) return prev;
+        const next = new Set(prev); next.delete(oldTag); next.add(newTag); return next;
+      }),
+    );
+  };
+
+  const handleMergeTag = async (sourceTag: string, targetTag: string) => {
+    const affected = todoItems.filter(item => item.categories?.includes(sourceTag));
+    await bulkUpdateCategories(
+      affected,
+      (item) => {
+        const cats = item.categories || [];
+        const without = cats.filter(c => c !== sourceTag);
+        return without.includes(targetTag) ? without : [...without, targetTag];
+      },
+      () => setSelectedCategories(prev => {
+        if (!prev.has(sourceTag)) return prev;
+        const next = new Set(prev); next.delete(sourceTag); next.add(targetTag); return next;
+      }),
+    );
+  };
+
+  const handleLogin = async () => {
+    try {
+      await graphLogin();
+    } catch (err) {
+      console.error('Login failed:', err);
+      setError('Login failed. Please try again.');
+    }
+  };
+
+  if (!bookId) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.inner}>
+          <div className={styles.warning}>
+            No book selected. Please select a book from the <Link href="/books" className={styles.warningLink}>Books page</Link>.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.inner}>
+        <div className={styles.card}>
+          <div className={styles.header}>
+            <div className={styles.headerInfo}>
+              <h1 className={styles.title}>Scrum Board</h1>
+              {calendars.length > 1 ? (
+                <select
+                  className={styles.bookSwitcher}
+                  value={bookId || ''}
+                  onChange={(e) => handleCalendarSwitch(e.target.value)}
+                >
+                  {calendars.map(cal => (
+                    <option key={cal.id} value={cal.id}>
+                      {getCalendarDisplayName(cal)}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <p className={styles.subtitle}>{currentCalendarName}</p>
+              )}
+            </div>
+            <div className={styles.actions}>
+              {!isAuthenticated ? (
+                <button
+                  onClick={handleLogin}
+                  disabled={inProgress !== 'none'}
+                  className={`${styles.button} ${styles.buttonPrimary}`}
+                >
+                  {inProgress !== 'none' ? 'Signing in...' : 'Sign In'}
+                </button>
+              ) : (
+                <>
+                  <AddTodoItem onAddTodo={handleAddTodo} disabled={loading} availableCategories={allCategories} />
+                  <button
+                    onClick={fetchEvents}
+                    disabled={loading}
+                    className={`${styles.button} ${styles.buttonSecondary}`}
+                  >
+                    {loading ? 'Loading...' : 'Refresh'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {displayError && (
+          <div className={styles.error} role="alert">
+            <span className={styles.errorTitle}>Error: </span>
+            <span>{displayError}</span>
+          </div>
+        )}
+
+        {loading && (
+          <div className={styles.loading}>
+            <div className={styles.spinner}></div>
+          </div>
+        )}
+
+        {!loading && isAuthenticated && (
+          <div className={styles.boardSection}>
+            <div className={styles.boardHeader}>
+              <span className={styles.filterCount}>
+                Showing {filteredItems.length} of {todoItems.length} items
+              </span>
+              <div className={styles.boardHeaderActions}>
+                {allCategories.length > 0 && (
+                  <>
+                    <button
+                      className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                      onClick={() => setShowTags(prev => !prev)}
+                    >
+                      {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
+                    </button>
+                    <button
+                      className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                      onClick={() => setShowManageTags(true)}
+                      title="Manage tags"
+                      aria-label="Manage tags"
+                      aria-haspopup="dialog"
+                    >
+                      ⚙
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {showTags && allCategories.length > 0 && (
+              <div className={styles.tagBar}>
+                <div className={styles.categoryFilterChips}>
+                  <button
+                    className={`${styles.categoryFilterChip} ${showUncategorized ? styles.categoryFilterChipActive : ''}`}
+                    onClick={() => setShowUncategorized(prev => !prev)}
+                  >
+                    Untagged
+                  </button>
+                  {allCategories.map(cat => {
+                    const isSelected = selectedCategories.has(cat);
+                    return (
+                      <button
+                        key={cat}
+                        className={`${styles.categoryFilterChip} ${isSelected ? styles.categoryFilterChipActive : ''}`}
+                        onClick={() => setSelectedCategories(prev => {
+                          const next = new Set(prev);
+                          if (isSelected) next.delete(cat); else next.add(cat);
+                          return next;
+                        })}
+                      >
+                        {cat}
+                      </button>
+                    );
+                  })}
+                  {categoryFilterActive && (
+                    <button
+                      className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
+                      onClick={() => { setSelectedCategories(new Set()); setShowUncategorized(false); }}
+                    >
+                      ✕ Clear
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div className={styles.board}>
+              {LANE_STATUSES.map(status => {
+                const items = lanes[status] || [];
+                const laneStyle = LANE_STYLES[status];
+                return (
+                  <div
+                    key={status}
+                    className={`${styles.lane} ${laneStyle.lane} ${draggedItem ? styles.laneDropZone : ''}`}
+                    onDragOver={handleDragOver}
+                    onDrop={() => handleDrop(status)}
+                  >
+                    <div className={styles.laneHeader}>
+                      <h3 className={`${styles.laneTitle} ${laneStyle.title}`}>
+                        {STATUS_LABELS[status]}
+                      </h3>
+                      <span className={styles.laneCount}>{items.length}</span>
+                    </div>
+                    <div className={styles.laneContent}>
+                      {items.map(todo => (
+                        <ScrumCard
+                          key={todo.id}
+                          todo={todo}
+                          onDragStart={handleDragStart}
+                          onClick={setSelectedTodo}
+                        />
+                      ))}
+                      {items.length === 0 && (
+                        <p className={styles.laneEmpty}>No items</p>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {selectedTodo && (
+          <ViewTodoItem
+            todo={selectedTodo}
+            onClose={() => setSelectedTodo(null)}
+            onUpdate={handleUpdateTodo}
+            availableCategories={allCategories}
+          />
+        )}
+
+        {showManageTags && (
+          <ManageTags
+            tags={allCategories}
+            todoItems={todoItems}
+            onRenameTag={handleRenameTag}
+            onDeleteTag={handleDeleteTag}
+            onMergeTag={handleMergeTag}
+            onClose={() => setShowManageTags(false)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ScrumPage() {
+  return (
+    <Suspense fallback={
+      <div className={styles.container}>
+        <div className={styles.inner}>
+          <div className={styles.loading}><div className={styles.spinner}></div></div>
+        </div>
+      </div>
+    }>
+      <ScrumPageContent />
+    </Suspense>
+  );
+}

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -79,7 +79,7 @@ function ScrumPageContent() {
   }, [todoItems, selectedCategories, showUncategorized, categoryFilterActive]);
 
   const lanes = useMemo(() => {
-    const result: Record<string, (TodoItem & { id?: string })[]> = {};
+    const result = {} as Record<LaneStatus, (TodoItem & { id?: string })[]>;
     for (const status of LANE_STATUSES) {
       result[status] = sortByPriority(filteredItems.filter(t => (t.status || 'new') === status));
     }

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -18,6 +18,7 @@ const BASE_NAV_ITEMS: NavItem[] = [
   { href: '/', label: 'Home', icon: '🏠' },
   { href: '/books', label: 'My Books', icon: '📚' },
   { href: '/matrix', label: 'Matrix', icon: '📊', matchPrefix: true },
+  { href: '/scrum', label: 'Scrum Board', icon: '🏃', matchPrefix: true },
   { href: '/cancelled', label: 'Cancelled Tasks', icon: '🗑️', matchPrefix: true },
 ];
 

--- a/src/arrange-v4/components/ScrumCard.module.css
+++ b/src/arrange-v4/components/ScrumCard.module.css
@@ -1,0 +1,75 @@
+.card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  background-color: white;
+  cursor: move;
+  transition: box-shadow 0.2s;
+}
+
+.card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.card[draggable="true"]:active {
+  cursor: grabbing;
+  opacity: 0.5;
+}
+
+.subject {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #111827;
+  margin-bottom: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.badgeImportant {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.badgeUrgent {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.eta {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.categories {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.category {
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background-color: #dbeafe;
+  color: #1e40af;
+}

--- a/src/arrange-v4/components/ScrumCard.module.css
+++ b/src/arrange-v4/components/ScrumCard.module.css
@@ -4,12 +4,16 @@
   padding: 12px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   background-color: white;
-  cursor: move;
+  cursor: pointer;
   transition: box-shadow 0.2s;
 }
 
 .card:hover {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.card[draggable="true"] {
+  cursor: grab;
 }
 
 .card[draggable="true"]:active {

--- a/src/arrange-v4/components/ScrumCard.tsx
+++ b/src/arrange-v4/components/ScrumCard.tsx
@@ -6,10 +6,11 @@ import styles from './ScrumCard.module.css';
 interface ScrumCardProps {
   todo: TodoItem & { id?: string };
   onDragStart?: (todo: TodoItem & { id?: string }) => void;
+  onDragEnd?: () => void;
   onClick?: (todo: TodoItem & { id?: string }) => void;
 }
 
-export default function ScrumCard({ todo, onDragStart, onClick }: ScrumCardProps) {
+export default function ScrumCard({ todo, onDragStart, onDragEnd, onClick }: ScrumCardProps) {
   const formatShortDate = (dateStr?: string) => {
     if (!dateStr) return null;
     const d = new Date(dateStr);
@@ -21,6 +22,7 @@ export default function ScrumCard({ todo, onDragStart, onClick }: ScrumCardProps
       className={styles.card}
       draggable={!!todo.id}
       onDragStart={() => onDragStart?.(todo)}
+      onDragEnd={() => onDragEnd?.()}
       onClick={() => onClick?.(todo)}
       role="button"
       tabIndex={0}

--- a/src/arrange-v4/components/ScrumCard.tsx
+++ b/src/arrange-v4/components/ScrumCard.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { TodoItem } from '@/lib/todoDataService';
+import styles from './ScrumCard.module.css';
+
+interface ScrumCardProps {
+  todo: TodoItem & { id?: string };
+  onDragStart?: (todo: TodoItem & { id?: string }) => void;
+  onClick?: (todo: TodoItem & { id?: string }) => void;
+}
+
+export default function ScrumCard({ todo, onDragStart, onClick }: ScrumCardProps) {
+  const formatShortDate = (dateStr?: string) => {
+    if (!dateStr) return null;
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  };
+
+  return (
+    <div
+      className={styles.card}
+      draggable={!!todo.id}
+      onDragStart={() => onDragStart?.(todo)}
+      onClick={() => onClick?.(todo)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick?.(todo);
+        }
+      }}
+    >
+      <div className={styles.subject}>{todo.subject}</div>
+      <div className={styles.badges}>
+        {todo.important && <span className={`${styles.badge} ${styles.badgeImportant}`}>Important</span>}
+        {todo.urgent && <span className={`${styles.badge} ${styles.badgeUrgent}`}>Urgent</span>}
+        {todo.etaDateTime && (
+          <span className={styles.eta}>ETA: {formatShortDate(todo.etaDateTime)}</span>
+        )}
+      </div>
+      {todo.categories && todo.categories.length > 0 && (
+        <div className={styles.categories}>
+          {todo.categories.map(cat => (
+            <span key={cat} className={styles.category}>{cat}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Scrum Board** (Kanban) view with swimming lanes for task status management.

Closes #25

## What's New

- **`/scrum` page** — 4 swimming lanes: New → Blocked → In Progress → Finished
- **`ScrumCard` component** — simplified tile showing title, importance/urgency badges, ETA, and category tags
- **Drag-and-drop** between lanes changes task status with optimistic UI and rollback on failure
- **Sorting** within lanes: important items first, then urgent, then alphabetical
- **Full feature parity** with matrix page: book switcher, tag filters, Add TODO, click-to-view/edit detail via ViewTodoItem, ManageTags dialog
- **Responsive**: 4-column CSS grid on desktop, stacked on mobile
- **Navigation**: 🏃 Scrum Board entry in hamburger menu

## Files Changed (5 total, 4 new)

| File | Change |
|---|---|
| `components/ScrumCard.tsx` | **New** — simplified task tile |
| `components/ScrumCard.module.css` | **New** — card styles |
| `app/scrum/page.tsx` | **New** — scrum board page |
| `app/scrum/page.module.css` | **New** — lane layout styles |
| `components/HamburgerMenu.tsx` | Added nav entry |

## Testing
- ✅ `npm run build` passes
- ✅ Lint clean for new files