### PR TITLE
feat: Show relative ETA dates for nearby deadlines (#44)

### DIFF
--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback, useRef, Suspense } from 'react
 import { getAllCalendarEvents } from '@/lib/graphService';
 import { deleteTodoItem, TodoItem, parseTodoData } from '@/lib/todoDataService';
 import { getCalendarDisplayName } from '@/lib/calendarUtils';
+import { formatRelativeDate } from '@/lib/dateUtils';
 import { useGraphToken } from '@/lib/hooks/useGraphToken';
 import { useBookId } from '@/lib/hooks/useBookId';
 import { useSetTopBarActions } from '@/components/TopBarProvider';
@@ -272,7 +273,7 @@ function CancelledPageContent() {
                               <span>ETS: {new Date(todo.etsDateTime).toLocaleDateString()}</span>
                             )}
                             {todo.etaDateTime && (
-                              <span>ETA: {new Date(todo.etaDateTime).toLocaleDateString()}</span>
+                              <span>ETA: {formatRelativeDate(todo.etaDateTime)}</span>
                             )}
                           </div>
                         </div>

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -272,9 +272,12 @@ function CancelledPageContent() {
                             {todo.etsDateTime && (
                               <span>ETS: {new Date(todo.etsDateTime).toLocaleDateString()}</span>
                             )}
-                            {todo.etaDateTime && (
-                              <span>ETA: {formatRelativeDate(todo.etaDateTime)}</span>
-                            )}
+                            {todo.etaDateTime && (() => {
+                              const eta = formatRelativeDate(todo.etaDateTime);
+                              return (
+                                <span title={`ETA: ${eta.fullDate}`}>ETA: {eta.text}</span>
+                              );
+                            })()}
                           </div>
                         </div>
                         {todo.categories && todo.categories.length > 0 && (

--- a/src/arrange-v4/app/cancelled/page.tsx
+++ b/src/arrange-v4/app/cancelled/page.tsx
@@ -275,7 +275,12 @@ function CancelledPageContent() {
                             {todo.etaDateTime && (() => {
                               const eta = formatRelativeDate(todo.etaDateTime);
                               return (
-                                <span title={`ETA: ${eta.fullDate}`}>ETA: {eta.text}</span>
+                                <span
+                                  title={`ETA: ${eta.fullDate}`}
+                                  style={eta.isOverdue ? { color: '#dc2626', fontWeight: 600 } : undefined}
+                                >
+                                  ETA: {eta.text}
+                                </span>
                               );
                             })()}
                           </div>

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -624,6 +624,7 @@
 
 .todoDateOverdue:hover {
   color: #b91c1c;
+  border-bottom-color: #fca5a5;
 }
 
 .todoDateSep {

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -616,6 +616,16 @@
   border-bottom-color: #9ca3af;
 }
 
+.todoDateOverdue {
+  color: #dc2626;
+  font-weight: 600;
+  border-bottom-color: #fca5a5;
+}
+
+.todoDateOverdue:hover {
+  color: #b91c1c;
+}
+
 .todoDateSep {
   color: #d1d5db;
 }

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useMemo, useRef, Suspense } from 'react';
 import { getCalendars, getCalendarEvents } from '@/lib/graphService';
 import { createTodoItem, updateTodoItem, sweepStaleTodos, TodoItem, parseTodoData, TodoStatus, ALL_STATUSES, STATUS_LABELS } from '@/lib/todoDataService';
 import { filterArrangeCalendars, getCalendarDisplayName } from '@/lib/calendarUtils';
+import { formatRelativeDate } from '@/lib/dateUtils';
 import { hasSessionSweepRun, isSessionSweepInProgress, markSessionSweepInProgress, clearSessionSweepInProgress, markSessionSweepDone } from '@/lib/bookStorage';
 import { useGraphToken } from '@/lib/hooks/useGraphToken';
 import { useBookId } from '@/lib/hooks/useBookId';
@@ -110,7 +111,7 @@ function TodoCard({ todo, onDragStart, onClick, onStatusChange }: {
                   className={styles.todoDateValue}
                   title={`ETA: ${new Date(todo.etaDateTime).toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'short' })}`}
                 >
-                  {new Date(todo.etaDateTime).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                  {formatRelativeDate(todo.etaDateTime)}
                 </span>
               )}
             </div>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -106,14 +106,17 @@ function TodoCard({ todo, onDragStart, onClick, onStatusChange }: {
                 </span>
               )}
               {todo.etsDateTime && todo.etaDateTime && <span className={styles.todoDateSep}>→</span>}
-              {todo.etaDateTime && (
-                <span 
-                  className={styles.todoDateValue}
-                  title={`ETA: ${new Date(todo.etaDateTime).toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'short' })}`}
-                >
-                  {formatRelativeDate(todo.etaDateTime)}
-                </span>
-              )}
+              {todo.etaDateTime && (() => {
+                const eta = formatRelativeDate(todo.etaDateTime);
+                return (
+                  <span 
+                    className={`${styles.todoDateValue} ${eta.isOverdue ? styles.todoDateOverdue : ''}`}
+                    title={`ETA: ${eta.fullDate}`}
+                  >
+                    {eta.text}
+                  </span>
+                );
+              })()}
             </div>
           )}
           {/* Actual times */}

--- a/src/arrange-v4/components/ScrumCard.module.css
+++ b/src/arrange-v4/components/ScrumCard.module.css
@@ -63,6 +63,11 @@
   color: #6b7280;
 }
 
+.etaOverdue {
+  color: #dc2626;
+  font-weight: 600;
+}
+
 .categories {
   display: flex;
   gap: 4px;

--- a/src/arrange-v4/components/ScrumCard.tsx
+++ b/src/arrange-v4/components/ScrumCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { TodoItem } from '@/lib/todoDataService';
+import { formatRelativeDate } from '@/lib/dateUtils';
 import styles from './ScrumCard.module.css';
 
 interface ScrumCardProps {
@@ -11,11 +12,6 @@ interface ScrumCardProps {
 }
 
 export default function ScrumCard({ todo, onDragStart, onDragEnd, onClick }: ScrumCardProps) {
-  const formatShortDate = (dateStr?: string) => {
-    if (!dateStr) return null;
-    const d = new Date(dateStr);
-    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  };
 
   return (
     <div
@@ -37,9 +33,13 @@ export default function ScrumCard({ todo, onDragStart, onDragEnd, onClick }: Scr
       <div className={styles.badges}>
         {todo.important && <span className={`${styles.badge} ${styles.badgeImportant}`}>Important</span>}
         {todo.urgent && <span className={`${styles.badge} ${styles.badgeUrgent}`}>Urgent</span>}
-        {todo.etaDateTime && (
-          <span className={styles.eta}>ETA: {formatShortDate(todo.etaDateTime)}</span>
-        )}
+        {todo.etaDateTime && (() => {
+          const label = formatRelativeDate(todo.etaDateTime);
+          const isOverdue = label.includes('overdue');
+          return (
+            <span className={`${styles.eta} ${isOverdue ? styles.etaOverdue : ''}`}>ETA: {label}</span>
+          );
+        })()}
       </div>
       {todo.categories && todo.categories.length > 0 && (
         <div className={styles.categories}>

--- a/src/arrange-v4/components/ScrumCard.tsx
+++ b/src/arrange-v4/components/ScrumCard.tsx
@@ -34,10 +34,14 @@ export default function ScrumCard({ todo, onDragStart, onDragEnd, onClick }: Scr
         {todo.important && <span className={`${styles.badge} ${styles.badgeImportant}`}>Important</span>}
         {todo.urgent && <span className={`${styles.badge} ${styles.badgeUrgent}`}>Urgent</span>}
         {todo.etaDateTime && (() => {
-          const label = formatRelativeDate(todo.etaDateTime);
-          const isOverdue = label.includes('overdue');
+          const eta = formatRelativeDate(todo.etaDateTime);
           return (
-            <span className={`${styles.eta} ${isOverdue ? styles.etaOverdue : ''}`}>ETA: {label}</span>
+            <span
+              className={`${styles.eta} ${eta.isOverdue ? styles.etaOverdue : ''}`}
+              title={`ETA: ${eta.fullDate}`}
+            >
+              ETA: {eta.text}
+            </span>
           );
         })()}
       </div>

--- a/src/arrange-v4/lib/dateUtils.ts
+++ b/src/arrange-v4/lib/dateUtils.ts
@@ -24,6 +24,11 @@ export interface RelativeDateInfo {
  */
 export function formatRelativeDate(dateStr: string): RelativeDateInfo {
   const target = new Date(dateStr);
+
+  if (isNaN(target.getTime())) {
+    return { text: dateStr, isOverdue: false, fullDate: dateStr };
+  }
+
   const now = new Date();
   const fullDate = target.toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'short' });
 

--- a/src/arrange-v4/lib/dateUtils.ts
+++ b/src/arrange-v4/lib/dateUtils.ts
@@ -32,10 +32,10 @@ export function formatRelativeDate(dateStr: string): RelativeDateInfo {
   const now = new Date();
   const fullDate = target.toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'short' });
 
-  // Compare calendar days (strip time)
-  const targetDay = new Date(target.getFullYear(), target.getMonth(), target.getDate());
-  const todayDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const diffMs = targetDay.getTime() - todayDay.getTime();
+  // Compare calendar days using UTC to match the app's "today" semantics elsewhere
+  const targetDayUtcMs = Date.UTC(target.getUTCFullYear(), target.getUTCMonth(), target.getUTCDate());
+  const todayDayUtcMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const diffMs = targetDayUtcMs - todayDayUtcMs;
   const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
 
   const isOverdue = diffDays < 0;

--- a/src/arrange-v4/lib/dateUtils.ts
+++ b/src/arrange-v4/lib/dateUtils.ts
@@ -1,4 +1,16 @@
 /**
+ * Result of formatting a date relative to today.
+ */
+export interface RelativeDateInfo {
+  /** Display text, e.g. "in 3d", "2d overdue", "Jan 15" */
+  text: string;
+  /** True when the date is in the past */
+  isOverdue: boolean;
+  /** Full absolute date string for use in tooltips */
+  fullDate: string;
+}
+
+/**
  * Formats a date as a relative string when it's within ±14 days of now,
  * otherwise falls back to a short absolute date (e.g. "Jan 15").
  *
@@ -10,9 +22,10 @@
  *   - "2d overdue"
  *   - "Jan 15" (for dates further away)
  */
-export function formatRelativeDate(dateStr: string): string {
+export function formatRelativeDate(dateStr: string): RelativeDateInfo {
   const target = new Date(dateStr);
   const now = new Date();
+  const fullDate = target.toLocaleString(undefined, { dateStyle: 'full', timeStyle: 'short' });
 
   // Compare calendar days (strip time)
   const targetDay = new Date(target.getFullYear(), target.getMonth(), target.getDate());
@@ -20,11 +33,14 @@ export function formatRelativeDate(dateStr: string): string {
   const diffMs = targetDay.getTime() - todayDay.getTime();
   const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
 
-  if (diffDays === 0) return 'today';
-  if (diffDays === 1) return 'tomorrow';
-  if (diffDays === -1) return 'yesterday';
-  if (diffDays > 1 && diffDays <= 14) return `in ${diffDays}d`;
-  if (diffDays < -1 && diffDays >= -14) return `${Math.abs(diffDays)}d overdue`;
+  const isOverdue = diffDays < 0;
 
-  return target.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  if (diffDays === 0) return { text: 'today', isOverdue: false, fullDate };
+  if (diffDays === 1) return { text: 'tomorrow', isOverdue: false, fullDate };
+  if (diffDays === -1) return { text: 'yesterday', isOverdue: true, fullDate };
+  if (diffDays > 1 && diffDays <= 14) return { text: `in ${diffDays}d`, isOverdue: false, fullDate };
+  if (diffDays < -1 && diffDays >= -14) return { text: `${Math.abs(diffDays)}d overdue`, isOverdue: true, fullDate };
+
+  const text = target.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return { text, isOverdue, fullDate };
 }

--- a/src/arrange-v4/lib/dateUtils.ts
+++ b/src/arrange-v4/lib/dateUtils.ts
@@ -1,0 +1,30 @@
+/**
+ * Formats a date as a relative string when it's within ±14 days of now,
+ * otherwise falls back to a short absolute date (e.g. "Jan 15").
+ *
+ * Examples:
+ *   - "today"
+ *   - "tomorrow"
+ *   - "in 3d"
+ *   - "yesterday"
+ *   - "2d overdue"
+ *   - "Jan 15" (for dates further away)
+ */
+export function formatRelativeDate(dateStr: string): string {
+  const target = new Date(dateStr);
+  const now = new Date();
+
+  // Compare calendar days (strip time)
+  const targetDay = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  const todayDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diffMs = targetDay.getTime() - todayDay.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return 'tomorrow';
+  if (diffDays === -1) return 'yesterday';
+  if (diffDays > 1 && diffDays <= 14) return `in ${diffDays}d`;
+  if (diffDays < -1 && diffDays >= -14) return `${Math.abs(diffDays)}d overdue`;
+
+  return target.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}


### PR DESCRIPTION
## Summary

Shows relative ETA dates like "in 3d" or "2d overdue" instead of absolute dates when deadlines are within ±14 days. Overdue items are highlighted in red.

Closes #44

## Examples

| ETA date | Display |
|---|---|
| Today | `today` |
| Tomorrow | `tomorrow` |
| Yesterday | `yesterday` |
| 3 days from now | `in 3d` |
| 2 days ago | `2d overdue` (red) |
| 30 days away | `Jan 15` (absolute) |

Full absolute date is preserved on hover tooltip.

## Files Changed

| File | Change |
|---|---|
| `lib/dateUtils.ts` | **New** — `formatRelativeDate()` helper |
| `components/ScrumCard.tsx` | Uses relative ETA, overdue styling |
| `components/ScrumCard.module.css` | Added `.etaOverdue` red style |
| `app/matrix/page.tsx` | TodoCard uses relative ETA |
| `app/cancelled/page.tsx` | Task list uses relative ETA |

## Testing
- ✅ `npm run build` passes