### PR TITLE
fix: Combine Tags toggle and settings into combo button (#47)

### DIFF
--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -217,6 +217,44 @@
   padding: 4px 12px;
 }
 
+/* Combo button: two buttons joined as one */
+.comboButton {
+  display: inline-flex;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #d1d5db;
+}
+
+.comboButtonMain {
+  font-weight: 500;
+  font-size: 0.75rem;
+  padding: 4px 12px;
+  background-color: #e5e7eb;
+  color: #374151;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  border-right: 1px solid #d1d5db;
+}
+
+.comboButtonMain:hover {
+  background-color: #d1d5db;
+}
+
+.comboButtonAction {
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  background-color: #e5e7eb;
+  color: #374151;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.comboButtonAction:hover {
+  background-color: #d1d5db;
+}
+
 .filterCount {
   font-size: 0.8rem;
   color: #6b7280;

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -225,6 +225,10 @@
   border: 1px solid #d1d5db;
 }
 
+.comboButton:focus-within {
+  box-shadow: 0 0 0 2px #2563eb;
+}
+
 .comboButtonMain {
   font-weight: 500;
   font-size: 0.75rem;
@@ -235,6 +239,7 @@
   cursor: pointer;
   transition: background-color 0.2s;
   border-right: 1px solid #d1d5db;
+  outline: none;
 }
 
 .comboButtonMain:hover {
@@ -249,6 +254,7 @@
   border: none;
   cursor: pointer;
   transition: background-color 0.2s;
+  outline: none;
 }
 
 .comboButtonAction:hover {

--- a/src/arrange-v4/app/matrix/page.module.css
+++ b/src/arrange-v4/app/matrix/page.module.css
@@ -246,6 +246,10 @@
   background-color: #d1d5db;
 }
 
+.comboButtonMain:focus-visible {
+  background-color: #d1d5db;
+}
+
 .comboButtonAction {
   font-size: 0.75rem;
   padding: 4px 8px;
@@ -258,6 +262,10 @@
 }
 
 .comboButtonAction:hover {
+  background-color: #d1d5db;
+}
+
+.comboButtonAction:focus-visible {
   background-color: #d1d5db;
 }
 

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -648,15 +648,15 @@ function MatrixPageContent() {
                 <span className={styles.filterCount}>Showing {filteredTodoItems.length} of {todoItems.length} items</span>
                 <div className={styles.matrixHeaderActions}>
                   {allCategories.length > 0 && (
-                    <>
+                    <div className={styles.comboButton}>
                       <button
-                        className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                        className={`${styles.comboButtonMain} ${styles.filterToggle}`}
                         onClick={() => setShowTags(prev => !prev)}
                       >
                         {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
                       </button>
                       <button
-                        className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                        className={`${styles.comboButtonAction} ${styles.filterToggle}`}
                         onClick={() => setShowManageTags(true)}
                         title="Manage tags"
                         aria-label="Manage tags"
@@ -664,7 +664,7 @@ function MatrixPageContent() {
                       >
                         ⚙
                       </button>
-                    </>
+                    </div>
                   )}
                   <button
                     className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -652,6 +652,7 @@ function MatrixPageContent() {
                       <button
                         className={styles.comboButtonMain}
                         onClick={() => setShowTags(prev => !prev)}
+                        aria-expanded={showTags}
                       >
                         {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
                       </button>

--- a/src/arrange-v4/app/matrix/page.tsx
+++ b/src/arrange-v4/app/matrix/page.tsx
@@ -650,13 +650,13 @@ function MatrixPageContent() {
                   {allCategories.length > 0 && (
                     <div className={styles.comboButton}>
                       <button
-                        className={`${styles.comboButtonMain} ${styles.filterToggle}`}
+                        className={styles.comboButtonMain}
                         onClick={() => setShowTags(prev => !prev)}
                       >
                         {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
                       </button>
                       <button
-                        className={`${styles.comboButtonAction} ${styles.filterToggle}`}
+                        className={styles.comboButtonAction}
                         onClick={() => setShowManageTags(true)}
                         title="Manage tags"
                         aria-label="Manage tags"

--- a/src/arrange-v4/app/scrum/page.module.css
+++ b/src/arrange-v4/app/scrum/page.module.css
@@ -170,6 +170,44 @@
   padding: 4px 12px;
 }
 
+/* Combo button: two buttons joined as one */
+.comboButton {
+  display: inline-flex;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #d1d5db;
+}
+
+.comboButtonMain {
+  font-weight: 500;
+  font-size: 0.8rem;
+  padding: 4px 12px;
+  background-color: #e5e7eb;
+  color: #374151;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  border-right: 1px solid #d1d5db;
+}
+
+.comboButtonMain:hover {
+  background-color: #d1d5db;
+}
+
+.comboButtonAction {
+  font-size: 0.8rem;
+  padding: 4px 8px;
+  background-color: #e5e7eb;
+  color: #374151;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.comboButtonAction:hover {
+  background-color: #d1d5db;
+}
+
 /* Tag bar */
 .tagBar {
   background-color: white;

--- a/src/arrange-v4/app/scrum/page.module.css
+++ b/src/arrange-v4/app/scrum/page.module.css
@@ -178,6 +178,10 @@
   border: 1px solid #d1d5db;
 }
 
+.comboButton:focus-within {
+  box-shadow: 0 0 0 2px #2563eb;
+}
+
 .comboButtonMain {
   font-weight: 500;
   font-size: 0.8rem;
@@ -188,6 +192,7 @@
   cursor: pointer;
   transition: background-color 0.2s;
   border-right: 1px solid #d1d5db;
+  outline: none;
 }
 
 .comboButtonMain:hover {
@@ -202,6 +207,7 @@
   border: none;
   cursor: pointer;
   transition: background-color 0.2s;
+  outline: none;
 }
 
 .comboButtonAction:hover {

--- a/src/arrange-v4/app/scrum/page.module.css
+++ b/src/arrange-v4/app/scrum/page.module.css
@@ -199,6 +199,10 @@
   background-color: #d1d5db;
 }
 
+.comboButtonMain:focus-visible {
+  background-color: #d1d5db;
+}
+
 .comboButtonAction {
   font-size: 0.8rem;
   padding: 4px 8px;
@@ -211,6 +215,10 @@
 }
 
 .comboButtonAction:hover {
+  background-color: #d1d5db;
+}
+
+.comboButtonAction:focus-visible {
   background-color: #d1d5db;
 }
 

--- a/src/arrange-v4/app/scrum/page.module.css
+++ b/src/arrange-v4/app/scrum/page.module.css
@@ -165,11 +165,6 @@
   color: #6b7280;
 }
 
-.filterToggle {
-  font-size: 0.8rem;
-  padding: 4px 12px;
-}
-
 /* Combo button: two buttons joined as one */
 .comboButton {
   display: inline-flex;

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -374,15 +374,15 @@ function ScrumPageContent() {
               </span>
               <div className={styles.boardHeaderActions}>
                 {allCategories.length > 0 && (
-                  <>
+                  <div className={styles.comboButton}>
                     <button
-                      className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                      className={`${styles.comboButtonMain} ${styles.filterToggle}`}
                       onClick={() => setShowTags(prev => !prev)}
                     >
                       {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
                     </button>
                     <button
-                      className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
+                      className={`${styles.comboButtonAction} ${styles.filterToggle}`}
                       onClick={() => setShowManageTags(true)}
                       title="Manage tags"
                       aria-label="Manage tags"
@@ -390,7 +390,7 @@ function ScrumPageContent() {
                     >
                       ⚙
                     </button>
-                  </>
+                  </div>
                 )}
               </div>
             </div>

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -378,6 +378,7 @@ function ScrumPageContent() {
                     <button
                       className={styles.comboButtonMain}
                       onClick={() => setShowTags(prev => !prev)}
+                      aria-expanded={showTags}
                     >
                       {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
                     </button>

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -376,13 +376,13 @@ function ScrumPageContent() {
                 {allCategories.length > 0 && (
                   <div className={styles.comboButton}>
                     <button
-                      className={`${styles.comboButtonMain} ${styles.filterToggle}`}
+                      className={styles.comboButtonMain}
                       onClick={() => setShowTags(prev => !prev)}
                     >
                       {showTags ? '▲' : '▼'} Tags{categoryFilterActive ? ' ●' : ''}
                     </button>
                     <button
-                      className={`${styles.comboButtonAction} ${styles.filterToggle}`}
+                      className={styles.comboButtonAction}
                       onClick={() => setShowManageTags(true)}
                       title="Manage tags"
                       aria-label="Manage tags"


### PR DESCRIPTION
## Summary

Combines the separate "Tags" toggle button and "⚙" manage tags button into a single joined combo button for a cleaner, more intuitive UI.

Closes #47

## Before / After

**Before:** Two separate buttons — `[▼ Tags]` `[⚙]` — the gear's purpose was unclear.

**After:** One combo button — `[▼ Tags | ⚙]` — left side toggles the tag filter bar, right side opens Manage Tags dialog.

## Files Changed

| File | Change |
|---|---|
| `app/matrix/page.tsx` | Combo button markup |
| `app/matrix/page.module.css` | Combo button styles |
| `app/scrum/page.tsx` | Combo button markup |
| `app/scrum/page.module.css` | Combo button styles |

## Testing
- ✅ `npm run build` passes