### PR TITLE
fix: Hide ETA on finished/cancelled items in ScrumCard (#52)

### DIFF
--- a/src/arrange-v4/components/ScrumCard.tsx
+++ b/src/arrange-v4/components/ScrumCard.tsx
@@ -33,7 +33,7 @@ export default function ScrumCard({ todo, onDragStart, onDragEnd, onClick }: Scr
       <div className={styles.badges}>
         {todo.important && <span className={`${styles.badge} ${styles.badgeImportant}`}>Important</span>}
         {todo.urgent && <span className={`${styles.badge} ${styles.badgeUrgent}`}>Urgent</span>}
-        {todo.etaDateTime && (() => {
+        {todo.etaDateTime && todo.status !== 'finished' && todo.status !== 'cancelled' && (() => {
           const eta = formatRelativeDate(todo.etaDateTime);
           return (
             <span


### PR DESCRIPTION
## Summary

Hides the ETA badge on finished and cancelled tasks in the Scrum Board. ETA is irrelevant for terminal tasks — no point showing "overdue" on something already done.

Closes #52

## Change

One-line condition in `ScrumCard.tsx`: skip ETA rendering when `status === 'finished' || status === 'cancelled'`.

## Testing
- ✅ `npm run build` passes