### PR TITLE
feat: add swim lane status filter to scrum board

### DIFF
--- a/src/arrange-v4/app/scrum/page.module.css
+++ b/src/arrange-v4/app/scrum/page.module.css
@@ -14,8 +14,7 @@
 }
 
 .inner {
-  max-width: 100%;
-  margin: 0 auto;
+  width: 100%;
   padding: 32px 16px;
 }
 
@@ -302,7 +301,7 @@
 
 @media (min-width: 768px) {
   .board {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: var(--lane-columns, repeat(4, 1fr));
     flex: 1;
     min-height: 0;
   }
@@ -347,6 +346,11 @@
   border-color: #bbf7d0;
 }
 
+.laneCancelled {
+  background-color: #faf5ff;
+  border-color: #e9d5ff;
+}
+
 /* Drop zone */
 .laneDropZone {
   border: 3px dashed currentColor;
@@ -367,6 +371,10 @@
 
 .laneFinished.laneDropZone {
   border-color: #16a34a;
+}
+
+.laneCancelled.laneDropZone {
+  border-color: #9333ea;
 }
 
 @keyframes pulse {
@@ -394,6 +402,7 @@
 .laneTitleInProgress { color: #2563eb; }
 .laneTitleBlocked { color: #dc2626; }
 .laneTitleFinished { color: #16a34a; }
+.laneTitleCancelled { color: #9333ea; }
 
 .laneCount {
   font-size: 0.75rem;
@@ -437,3 +446,78 @@
     padding: 16px;
   }
 }
+
+/* Filter toggle */
+.filterToggle {
+  font-size: 0.75rem;
+  padding: 4px 12px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+}
+
+/* Status filter bar */
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 12px;
+  background-color: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.filterGroup {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.filterLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-width: 70px;
+}
+
+.filterModes {
+  display: flex;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.filterMode {
+  font-size: 0.625rem;
+  padding: 2px 8px;
+  border: none;
+  background-color: transparent;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-weight: 500;
+}
+
+.filterMode:not(:last-child) {
+  border-right: 1px solid #e5e7eb;
+}
+
+.filterMode:hover {
+  background-color: #f3f4f6;
+}
+
+.filterModeActive {
+  background-color: #2563eb;
+  color: white;
+  font-weight: 600;
+}
+
+.filterModeActive:hover {
+  background-color: #1d4ed8;
+}
+
+/* Status label colors in filter bar */
+.status_new { color: #6b7280; }
+.status_inProgress { color: #2563eb; }
+.status_blocked { color: #dc2626; }
+.status_finished { color: #16a34a; }
+.status_cancelled { color: #9333ea; }

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { getCalendarEvents } from '@/lib/graphService';
-import { createTodoItem, updateTodoItem, TodoItem, parseTodoData, TodoStatus, STATUS_LABELS } from '@/lib/todoDataService';
+import { createTodoItem, updateTodoItem, TodoItem, parseTodoData, TodoStatus, ALL_STATUSES, STATUS_LABELS } from '@/lib/todoDataService';
 import { getCalendarDisplayName } from '@/lib/calendarUtils';
 import { useGraphToken } from '@/lib/hooks/useGraphToken';
 import { useBookId } from '@/lib/hooks/useBookId';
@@ -14,7 +14,40 @@ import ScrumCard from '@/components/ScrumCard';
 import Link from 'next/link';
 import styles from './page.module.css';
 
-const LANE_STATUSES = ['new', 'blocked', 'inProgress', 'finished'] as const satisfies readonly TodoStatus[];
+type StatusFilterMode = 'showAll' | 'todayOnly' | 'hide';
+
+const FILTER_MODES: StatusFilterMode[] = ['showAll', 'todayOnly', 'hide'];
+
+const FILTER_MODE_LABELS: Record<StatusFilterMode, string> = {
+  showAll: 'All',
+  todayOnly: 'Today',
+  hide: 'Hide',
+};
+
+const DEFAULT_STATUS_FILTERS: Record<TodoStatus, StatusFilterMode> = {
+  new: 'showAll',
+  inProgress: 'showAll',
+  blocked: 'showAll',
+  finished: 'todayOnly',
+  cancelled: 'hide',
+};
+
+function isToday(dateStr: string | undefined | null): boolean {
+  if (!dateStr) return false;
+  const d = new Date(dateStr);
+  const now = new Date();
+  return d.getUTCFullYear() === now.getUTCFullYear() &&
+    d.getUTCMonth() === now.getUTCMonth() &&
+    d.getUTCDate() === now.getUTCDate();
+}
+
+function passesTodayFilter(todo: TodoItem): boolean {
+  const status = todo.status || 'new';
+  if (status === 'finished') return isToday(todo.finishDateTime);
+  return isToday(todo.etsDateTime);
+}
+
+const LANE_STATUSES = ['new', 'blocked', 'inProgress', 'finished', 'cancelled'] as const satisfies readonly TodoStatus[];
 type LaneStatus = (typeof LANE_STATUSES)[number];
 
 const LANE_STYLES: Record<LaneStatus, { lane: string; title: string }> = {
@@ -22,6 +55,7 @@ const LANE_STYLES: Record<LaneStatus, { lane: string; title: string }> = {
   inProgress: { lane: styles.laneInProgress, title: styles.laneTitleInProgress },
   blocked: { lane: styles.laneBlocked, title: styles.laneTitleBlocked },
   finished: { lane: styles.laneFinished, title: styles.laneTitleFinished },
+  cancelled: { lane: styles.laneCancelled, title: styles.laneTitleCancelled },
 };
 
 function sortByPriority(items: (TodoItem & { id?: string })[]) {
@@ -49,6 +83,8 @@ function ScrumPageContent() {
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set());
   const [showUncategorized, setShowUncategorized] = useState(false);
   const [showManageTags, setShowManageTags] = useState(false);
+  const [statusFilters, setStatusFilters] = useState<Record<TodoStatus, StatusFilterMode>>(DEFAULT_STATUS_FILTERS);
+  const [showStatusFilters, setShowStatusFilters] = useState(false);
 
   const displayError = error || calendarError;
 
@@ -64,10 +100,16 @@ function ScrumPageContent() {
 
   const categoryFilterActive = selectedCategories.size > 0 || showUncategorized;
 
+  const statusFilterActive = ALL_STATUSES.some(s => statusFilters[s] !== DEFAULT_STATUS_FILTERS[s]);
+
   const filteredItems = useMemo(() => {
     return todoItems.filter(todo => {
       const status = todo.status || 'new';
       if (!(LANE_STATUSES as readonly string[]).includes(status)) return false;
+
+      const mode = statusFilters[status as LaneStatus];
+      if (mode === 'hide') return false;
+      if (mode === 'todayOnly' && !passesTodayFilter(todo)) return false;
 
       if (categoryFilterActive) {
         const hasCats = todo.categories && todo.categories.length > 0;
@@ -77,7 +119,11 @@ function ScrumPageContent() {
       }
       return true;
     });
-  }, [todoItems, selectedCategories, showUncategorized, categoryFilterActive]);
+  }, [todoItems, selectedCategories, showUncategorized, categoryFilterActive, statusFilters]);
+
+  const visibleLanes = useMemo(() => {
+    return LANE_STATUSES.filter(s => statusFilters[s] !== 'hide');
+  }, [statusFilters]);
 
   const lanes = useMemo(() => {
     const result = {} as Record<LaneStatus, (TodoItem & { id?: string })[]>;
@@ -373,6 +419,12 @@ function ScrumPageContent() {
                 Showing {filteredItems.length} of {todoItems.length} items
               </span>
               <div className={styles.boardHeaderActions}>
+                <button
+                  className={`${styles.comboButtonMain} ${styles.filterToggle}`}
+                  onClick={() => setShowStatusFilters(prev => !prev)}
+                >
+                  {showStatusFilters ? '▲' : '▼'} Status{statusFilterActive ? ' ●' : ''}
+                </button>
                 {allCategories.length > 0 && (
                   <div className={styles.comboButton}>
                     <button
@@ -395,6 +447,35 @@ function ScrumPageContent() {
                 )}
               </div>
             </div>
+
+            {showStatusFilters && (
+              <div className={styles.filterBar}>
+                {ALL_STATUSES.map(status => (
+                  <div key={status} className={styles.filterGroup}>
+                    <span className={`${styles.filterLabel} ${styles[`status_${status}`]}`}>{STATUS_LABELS[status]}</span>
+                    <div className={styles.filterModes}>
+                      {FILTER_MODES.map(mode => (
+                        <button
+                          key={mode}
+                          className={`${styles.filterMode} ${statusFilters[status] === mode ? styles.filterModeActive : ''}`}
+                          onClick={() => setStatusFilters(prev => ({ ...prev, [status]: mode }))}
+                        >
+                          {FILTER_MODE_LABELS[mode]}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {statusFilterActive && (
+                  <button
+                    className={`${styles.categoryFilterChip} ${styles.categoryFilterClear}`}
+                    onClick={() => setStatusFilters(DEFAULT_STATUS_FILTERS)}
+                  >
+                    ✕ Reset
+                  </button>
+                )}
+              </div>
+            )}
 
             {showTags && allCategories.length > 0 && (
               <div className={styles.tagBar}>
@@ -433,8 +514,11 @@ function ScrumPageContent() {
               </div>
             )}
 
-            <div className={styles.board}>
-              {LANE_STATUSES.map(status => {
+            <div
+              className={styles.board}
+              style={{ '--lane-columns': `repeat(${visibleLanes.length || 1}, 1fr)` } as React.CSSProperties}
+            >
+              {visibleLanes.map(status => {
                 const items = lanes[status] || [];
                 const laneStyle = LANE_STYLES[status];
                 return (

--- a/src/arrange-v4/app/scrum/page.tsx
+++ b/src/arrange-v4/app/scrum/page.tsx
@@ -420,8 +420,9 @@ function ScrumPageContent() {
               </span>
               <div className={styles.boardHeaderActions}>
                 <button
-                  className={`${styles.comboButtonMain} ${styles.filterToggle}`}
+                  className={`${styles.button} ${styles.buttonSecondary} ${styles.filterToggle}`}
                   onClick={() => setShowStatusFilters(prev => !prev)}
+                  aria-expanded={showStatusFilters}
                 >
                   {showStatusFilters ? '▲' : '▼'} Status{statusFilterActive ? ' ●' : ''}
                 </button>
@@ -457,7 +458,9 @@ function ScrumPageContent() {
                       {FILTER_MODES.map(mode => (
                         <button
                           key={mode}
+                          type="button"
                           className={`${styles.filterMode} ${statusFilters[status] === mode ? styles.filterModeActive : ''}`}
+                          aria-pressed={statusFilters[status] === mode}
                           onClick={() => setStatusFilters(prev => ({ ...prev, [status]: mode }))}
                         >
                           {FILTER_MODE_LABELS[mode]}


### PR DESCRIPTION
## Summary

Closes #51 — adds a swim lane filter to the scrum board, matching the matrix view's status filter pattern.

### Changes

- **Status filter bar**: Collapsible bar with 3 modes per status: `All` / `Today` / `Hide`
- **5 filterable statuses**: New, Blocked, In Progress, Finished, Cancelled
- **Defaults**: New/Blocked/In Progress → Show All, Finished → Today, Cancelled → Hide
- **Dynamic grid**: Hidden lanes collapse entirely; remaining lanes expand to fill the width
- **Cancelled lane**: New purple-themed swim lane (hidden by default)
- **Reset button**: Appears when filters differ from defaults
- **Layout fix**: Changed `.inner` from `max-width: 100%` to `width: 100%` to prevent shrinking

### Files changed

- `src/arrange-v4/app/scrum/page.tsx` — filter state, logic, and UI
- `src/arrange-v4/app/scrum/page.module.css` — filter bar styles, cancelled lane, layout fix