### PR TITLE
feat: add PWA installability support

### DIFF
--- a/src/arrange-v4/app/layout.tsx
+++ b/src/arrange-v4/app/layout.tsx
@@ -18,6 +18,12 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Arrange V4",
   description: "Task management with Eisenhower Matrix",
+  themeColor: "#2563eb",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "Arrange",
+  },
   icons: {
     icon: [
       { url: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/icon-192.png`, sizes: "192x192", type: "image/png" },

--- a/src/arrange-v4/app/manifest.ts
+++ b/src/arrange-v4/app/manifest.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from 'next';
+
+export const dynamic = 'force-static';
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Arrange V4',
+    short_name: 'Arrange',
+    description: 'Task management with Eisenhower Matrix',
+    start_url: `${basePath}/`,
+    display: 'standalone',
+    background_color: '#f9fafb',
+    theme_color: '#2563eb',
+    icons: [
+      {
+        src: `${basePath}/icon-192.png`,
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: `${basePath}/icon-512.png`,
+        sizes: '512x512',
+        type: 'image/png',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

Closes #56 — adds Progressive Web App support so the app can be installed to home screens and app docks.

### Changes

- **`app/manifest.ts`** (new) — Web App Manifest via Next.js `MetadataRoute.Manifest`, pre-rendered at build time with basePath support
  - App name, description, icons (192px + 512px), `display: standalone`, theme colors
- **`app/layout.tsx`** — Added `themeColor` and `appleWebApp` metadata

### Generated HTML meta tags

```html
<link rel="manifest" href="/manifest.webmanifest">
<meta name="mobile-web-app-capable" content="yes">
<meta name="apple-mobile-web-app-title" content="Arrange">
<meta name="apple-mobile-web-app-status-bar-style" content="default">
```

### Scope

Installability only — no service worker or offline caching. A service worker can be added in a future iteration if offline support is desired.