### PR TITLE
feat: add quick view switcher for Matrix ↔ Scrum

### DIFF
--- a/src/arrange-v4/components/HamburgerMenu.module.css
+++ b/src/arrange-v4/components/HamburgerMenu.module.css
@@ -61,6 +61,41 @@
   flex-shrink: 0;
 }
 
+/* View switcher (Matrix ↔ Scrum) */
+.viewSwitcher {
+  display: inline-flex;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.viewSwitcherButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 30px;
+  font-size: 0.95rem;
+  background: transparent;
+  color: #6b7280;
+  text-decoration: none;
+  transition: background-color 0.15s;
+}
+
+.viewSwitcherButton:not(:last-child) {
+  border-right: 1px solid #e5e7eb;
+}
+
+.viewSwitcherButton:hover:not(.viewSwitcherActive) {
+  background-color: #f3f4f6;
+}
+
+.viewSwitcherActive {
+  background-color: #2563eb;
+  pointer-events: none;
+}
+
 .overlay {
   position: fixed;
   inset: 0;
@@ -271,5 +306,25 @@
 
   .overlay {
     background: rgba(0, 0, 0, 0.5);
+  }
+
+  .viewSwitcher {
+    border-color: #374151;
+  }
+
+  .viewSwitcherButton {
+    color: #9ca3af;
+  }
+
+  .viewSwitcherButton:not(:last-child) {
+    border-right-color: #374151;
+  }
+
+  .viewSwitcherButton:hover:not(.viewSwitcherActive) {
+    background-color: #374151;
+  }
+
+  .viewSwitcherActive {
+    background-color: #2563eb;
   }
 }

--- a/src/arrange-v4/components/HamburgerMenu.module.css
+++ b/src/arrange-v4/components/HamburgerMenu.module.css
@@ -87,13 +87,18 @@
   border-right: 1px solid #e5e7eb;
 }
 
+.viewSwitcherButton:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px #1d4ed8;
+}
+
 .viewSwitcherButton:hover:not(.viewSwitcherActive) {
   background-color: #f3f4f6;
 }
 
 .viewSwitcherActive {
   background-color: #2563eb;
-  pointer-events: none;
+  color: #ffffff;
 }
 
 .overlay {

--- a/src/arrange-v4/components/HamburgerMenu.module.css
+++ b/src/arrange-v4/components/HamburgerMenu.module.css
@@ -331,5 +331,6 @@
 
   .viewSwitcherActive {
     background-color: #2563eb;
+    color: #ffffff;
   }
 }

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -40,11 +40,12 @@ export default function HamburgerMenu() {
   const isOnScrum = pathname.startsWith('/scrum');
   const showViewSwitcher = isOnMatrix || isOnScrum;
 
-  const urlBookId = typeof window !== 'undefined'
-    ? new URLSearchParams(window.location.search).get('bookId')
-    : null;
-  const viewSwitcherBookId = urlBookId || getLastBookId();
-  const viewSwitcherQuery = viewSwitcherBookId ? `?bookId=${encodeURIComponent(viewSwitcherBookId)}` : '';
+  const [viewSwitcherQuery, setViewSwitcherQuery] = useState('');
+  useEffect(() => {
+    const urlBookId = new URLSearchParams(window.location.search).get('bookId');
+    const bookId = urlBookId || getLastBookId();
+    setViewSwitcherQuery(bookId ? `?bookId=${encodeURIComponent(bookId)}` : '');
+  }, [pathname]);
   const matrixHref = `/matrix${viewSwitcherQuery}`;
   const scrumHref = `/scrum${viewSwitcherQuery}`;
 

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -36,6 +36,15 @@ export default function HamburgerMenu() {
 
   const isAuthenticated = accounts.length > 0;
 
+  const isOnMatrix = pathname.startsWith('/matrix');
+  const isOnScrum = pathname.startsWith('/scrum');
+  const showViewSwitcher = isOnMatrix || isOnScrum;
+
+  const viewSwitcherBookId = getLastBookId();
+  const viewSwitcherQuery = viewSwitcherBookId ? `?bookId=${encodeURIComponent(viewSwitcherBookId)}` : '';
+  const matrixHref = `/matrix${viewSwitcherQuery}`;
+  const scrumHref = `/scrum${viewSwitcherQuery}`;
+
   function isActive(item: NavItem): boolean {
     if (item.matchPrefix) {
       const basePath = item.href.split('?')[0];
@@ -122,6 +131,26 @@ export default function HamburgerMenu() {
             ☰
           </button>
           <h1 className={styles.pageLabel}>{pageLabel}</h1>
+          {showViewSwitcher && (
+            <div className={styles.viewSwitcher} role="navigation" aria-label="Switch view">
+              <Link
+                href={matrixHref}
+                className={`${styles.viewSwitcherButton} ${isOnMatrix ? styles.viewSwitcherActive : ''}`}
+                aria-label="Matrix view"
+                aria-current={isOnMatrix ? 'page' : undefined}
+              >
+                📊
+              </Link>
+              <Link
+                href={scrumHref}
+                className={`${styles.viewSwitcherButton} ${isOnScrum ? styles.viewSwitcherActive : ''}`}
+                aria-label="Scrum view"
+                aria-current={isOnScrum ? 'page' : undefined}
+              >
+                🏃
+              </Link>
+            </div>
+          )}
           {leftActions}
         </div>
         <div className={styles.topBarMiddle} />

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -154,7 +154,7 @@ export default function HamburgerMenu() {
           </button>
           <h1 className={styles.pageLabel}>{pageLabel}</h1>
           {showViewSwitcher && (
-            <Suspense>
+            <Suspense fallback={null}>
               <ViewSwitcherInner isOnMatrix={isOnMatrix} isOnScrum={isOnScrum} />
             </Suspense>
           )}

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, Suspense } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useMsal } from '@azure/msal-react';
 import { getLastBookId } from '@/lib/bookStorage';
 import { useTopBarActions } from './TopBarProvider';
@@ -25,6 +25,33 @@ const BASE_NAV_ITEMS: NavItem[] = [
   { href: '/cancelled', label: 'Cancelled Tasks', icon: '🗑️', matchPrefix: true },
 ];
 
+function ViewSwitcherInner({ isOnMatrix, isOnScrum }: { isOnMatrix: boolean; isOnScrum: boolean }) {
+  const searchParams = useSearchParams();
+  const bookId = searchParams.get('bookId') || getLastBookId();
+  const query = bookId ? `?bookId=${encodeURIComponent(bookId)}` : '';
+
+  return (
+    <div className={styles.viewSwitcher} role="navigation" aria-label="Switch view">
+      <Link
+        href={`/matrix${query}`}
+        className={`${styles.viewSwitcherButton} ${isOnMatrix ? styles.viewSwitcherActive : ''}`}
+        aria-label="Matrix view"
+        aria-current={isOnMatrix ? 'page' : undefined}
+      >
+        📊
+      </Link>
+      <Link
+        href={`/scrum${query}`}
+        className={`${styles.viewSwitcherButton} ${isOnScrum ? styles.viewSwitcherActive : ''}`}
+        aria-label="Scrum view"
+        aria-current={isOnScrum ? 'page' : undefined}
+      >
+        🏃
+      </Link>
+    </div>
+  );
+}
+
 export default function HamburgerMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const [navItems, setNavItems] = useState<NavItem[]>(BASE_NAV_ITEMS);
@@ -39,15 +66,6 @@ export default function HamburgerMenu() {
   const isOnMatrix = pathname.startsWith('/matrix');
   const isOnScrum = pathname.startsWith('/scrum');
   const showViewSwitcher = isOnMatrix || isOnScrum;
-
-  const [viewSwitcherQuery, setViewSwitcherQuery] = useState('');
-  useEffect(() => {
-    const urlBookId = new URLSearchParams(window.location.search).get('bookId');
-    const bookId = urlBookId || getLastBookId();
-    setViewSwitcherQuery(bookId ? `?bookId=${encodeURIComponent(bookId)}` : '');
-  }, [pathname]);
-  const matrixHref = `/matrix${viewSwitcherQuery}`;
-  const scrumHref = `/scrum${viewSwitcherQuery}`;
 
   function isActive(item: NavItem): boolean {
     if (item.matchPrefix) {
@@ -136,24 +154,9 @@ export default function HamburgerMenu() {
           </button>
           <h1 className={styles.pageLabel}>{pageLabel}</h1>
           {showViewSwitcher && (
-            <div className={styles.viewSwitcher} role="navigation" aria-label="Switch view">
-              <Link
-                href={matrixHref}
-                className={`${styles.viewSwitcherButton} ${isOnMatrix ? styles.viewSwitcherActive : ''}`}
-                aria-label="Matrix view"
-                aria-current={isOnMatrix ? 'page' : undefined}
-              >
-                📊
-              </Link>
-              <Link
-                href={scrumHref}
-                className={`${styles.viewSwitcherButton} ${isOnScrum ? styles.viewSwitcherActive : ''}`}
-                aria-label="Scrum view"
-                aria-current={isOnScrum ? 'page' : undefined}
-              >
-                🏃
-              </Link>
-            </div>
+            <Suspense>
+              <ViewSwitcherInner isOnMatrix={isOnMatrix} isOnScrum={isOnScrum} />
+            </Suspense>
           )}
           {leftActions}
         </div>

--- a/src/arrange-v4/components/HamburgerMenu.tsx
+++ b/src/arrange-v4/components/HamburgerMenu.tsx
@@ -40,7 +40,10 @@ export default function HamburgerMenu() {
   const isOnScrum = pathname.startsWith('/scrum');
   const showViewSwitcher = isOnMatrix || isOnScrum;
 
-  const viewSwitcherBookId = getLastBookId();
+  const urlBookId = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('bookId')
+    : null;
+  const viewSwitcherBookId = urlBookId || getLastBookId();
   const viewSwitcherQuery = viewSwitcherBookId ? `?bookId=${encodeURIComponent(viewSwitcherBookId)}` : '';
   const matrixHref = `/matrix${viewSwitcherQuery}`;
   const scrumHref = `/scrum${viewSwitcherQuery}`;


### PR DESCRIPTION
## Summary

Closes #59 — switching between Matrix and Scrum views no longer requires opening the hamburger menu.

### Changes

Adds a compact segmented control (`📊 | 🏃`) directly in the top bar, visible only when on the Matrix or Scrum pages.

- **One tap** switches between views (no menu needed)
- **Preserves bookId** — uses `getLastBookId()` from localStorage
- **Active view** highlighted with blue background (`#2563eb`)
- **Accessible** — `aria-label`, `aria-current="page"`, `role="navigation"`
- **Dark mode** support included

### Files changed

- `components/HamburgerMenu.tsx` — view switcher logic and rendering
- `components/HamburgerMenu.module.css` — segmented control styles + dark mode